### PR TITLE
fixed injection to make jackrabbit_jar config be handled by JackrabbitCommand

### DIFF
--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -58,6 +58,10 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         $configuration = new Configuration($container->getParameter('kernel.debug'));
         $config = $processor->processConfiguration($configuration, $configs);
 
+        if (isset($config['jackrabbit_jar'])) {
+            $container->setParameter('doctrine_phpcr.jackrabbit_jar', $config['jackrabbit_jar']);
+        }
+
         if (!empty($config['session'])) {
             $this->sessionLoad($config['session'], $container);
         }


### PR DESCRIPTION
now you can use the following in app/config.yml:

```
doctrine_phpcr:
    jackrabbit_jar: "%kernel.root_dir%/Resources/java/jackrabbit-standalone.jar"
```

and use:
    php app/console doctrine:phpcr:jackrabbit start
