### PR TITLE
make imagine optional even when using the image form type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -154,7 +154,7 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('document_manager')
                     ->append($this->getOdmDocumentManagersNode())
                     ->append($this->getOdmLocaleNode())
-                    ->append($this->getOdmImagineNode())
+                    ->append($this->getOdmImageNode())
                 ->end()
             ->end()
         ;
@@ -247,19 +247,17 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function getOdmImagineNode()
+    private function getOdmImageNode()
     {
         $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('imagine');
+        $node = $treeBuilder->root('image');
 
         $node
             ->children()
-                ->scalarNode('enabled')->defaultValue(false)->end()
-                    ->scalarNode('filter')->defaultValue('image_upload_thumbnail')->end()
-                    ->arrayNode('extra_filters')
-                        ->requiresAtLeastOneElement()
-                        ->prototype('scalar')->end()
-                    ->end()
+                ->scalarNode('imagine_filter')->end()
+                ->arrayNode('extra_filters')
+                    ->requiresAtLeastOneElement()
+                    ->prototype('scalar')->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -252,17 +252,15 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
             $dm->addMethodCall('setLocaleChooserStrategy', array(new Reference('doctrine_phpcr.odm.locale_chooser')));
         }
 
-        if (isset($config['imagine']['enabled']) && $config['imagine']['enabled']) {
-            $filter = $config['imagine']['filter'];
-            $filters = isset($config['imagine']['extra_filters']) && is_array($config['imagine']['extra_filters'])
-                ? $config['imagine']['extra_filters']
-                : array();
-
-            $filters[] = $filter;
-            $container->setParameter('doctrine_phpcr.odm.subscriber.image_cache.filter', $filter);
-            $container->setParameter('doctrine_phpcr.odm.subscriber.image_cache.all_filters', $filters);
-            $this->loader->load('odm_image.xml');
-        }
+        $filter = isset($config['image']['imagine_filter'])
+            ? $config['image']['imagine_filter']
+            : false;
+        $filters = isset($config['image']['extra_filters']) && is_array($config['image']['extra_filters'])
+            ? array_merge(array($filter), $config['image']['extra_filters'])
+            : array();
+        $container->setParameter('doctrine_phpcr.odm.subscriber.image_cache.filter', $filter);
+        $container->setParameter('doctrine_phpcr.odm.subscriber.image_cache.all_filters', $filters);
+        $this->loader->load('odm_image.xml');
 
         $documentManagers = array();
         foreach ($config['document_managers'] as $name => $documentManager) {

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -1,6 +1,8 @@
 {% block phpcr_odm_image_widget %}
     {{ form_widget(form) }}
-    {% if form.vars.data %}
-        <img src="{{ form.vars.data | imagine_filter( imagine_filter ) }}" alt="" />
-    {% endif %}
+    {% block phpcr_odm_image_widget_preview %}
+        {% if form.vars.data and imagine_filter %}
+            <img src="{{ form.vars.data | imagine_filter( imagine_filter ) }}" alt="" />
+        {% endif %}
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
i noticed that the image form type could be useful even without having imagine. this is a slight bc break on the configuration but i think its worth it.

would update the documentation as well if we merge this
