### PR TITLE
Configurable array key

### DIFF
--- a/Form/DataTransformer/ReferenceManyCollectionToArrayTransformer.php
+++ b/Form/DataTransformer/ReferenceManyCollectionToArrayTransformer.php
@@ -8,7 +8,6 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 
 class ReferenceManyCollectionToArrayTransformer implements DataTransformerInterface
 {
-
     const KEY_PATH = 'path';
     const KEY_UUID = 'uuid';
 
@@ -33,7 +32,7 @@ class ReferenceManyCollectionToArrayTransformer implements DataTransformerInterf
      * @param string $key
      * @throws \InvalidArgumentException
      */
-    function __construct(DocumentManager $dm, $referencedClass, $key)
+    function __construct(DocumentManager $dm, $referencedClass, $key = self::KEY_UUID)
     {
         $this->dm = $dm;
         $this->referencedClass = $referencedClass;

--- a/Form/Type/PHPCRODMReferenceCollectionType.php
+++ b/Form/Type/PHPCRODMReferenceCollectionType.php
@@ -50,7 +50,7 @@ class PHPCRODMReferenceCollectionType extends AbstractType
         $resolver->setOptional(array('key'));
 
         $resolver->setDefaults(array(
-            'key' => ReferenceManyCollectionToArrayTransformer::KEY_PATH,
+            'key' => ReferenceManyCollectionToArrayTransformer::KEY_UUID,
         ));
     }
 


### PR DESCRIPTION
Let the user choose wether to use the uuid or the path of the node as an array key. This PR includes no BC break
