### PR TITLE
changed Symfony dependencies to allow all future versions of Symfony 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": ">=2.1,<2.3-dev",
-        "symfony/doctrine-bridge": ">=2.1,<2.3-dev",
+        "symfony/framework-bundle": "~2.1",
+        "symfony/doctrine-bridge": "~2.1",
         "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "~1.0-beta9"
     },


### PR DESCRIPTION
As the first LTS release of Symfony is about to be made, it seems reasonable to open Symfony dependencies to allow all remaining Symfony 2.x releases.
