### PR TITLE
Fix bug with Field Type Guessing in forms. Proxy moved to doctrine/commo...

### DIFF
--- a/Resources/config/phpcr.xml
+++ b/Resources/config/phpcr.xml
@@ -28,7 +28,7 @@
             <argument>%doctrine_phpcr.odm.document_managers%</argument>
             <argument>%doctrine_phpcr.default_session%</argument>
             <argument>%doctrine_phpcr.odm.default_document_manager%</argument>
-            <argument>Doctrine\ODM\PHPCR\Proxy\Proxy</argument>
+            <argument>Doctrine\Common\Proxy\Proxy</argument>
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>


### PR DESCRIPTION
Fix for field type guesser in forms.

Pls remember to update dependency in symfony-cmf/symfony-cmf:
$ composer depends doctrine/phpcr-bundle
...
symfony-cmf/symfony-cmf requires doctrine/phpcr-bundle (1.0.0-alpha4)
..
