### PR TITLE
Added command to re-class/ify/ documents

### DIFF
--- a/DoctrinePHPCRBundle.php
+++ b/DoctrinePHPCRBundle.php
@@ -34,6 +34,7 @@ use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\InitDoctrineDbalComman
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\JackrabbitCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\InfoDoctrineCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\RepositoryInitCommand;
+use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\DocumentMigrateClassCommand;
 
 class DoctrinePHPCRBundle extends Bundle
 {
@@ -58,6 +59,7 @@ class DoctrinePHPCRBundle extends Bundle
         if (class_exists('Doctrine\ODM\PHPCR\Version')) {
             $application->add(new InfoDoctrineCommand());
             $application->add(new RepositoryInitCommand());
+            $application->add(new DocumentMigrateClassCommand());
         }
 
         if (class_exists('\Jackalope\Tools\Console\Command\JackrabbitCommand')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | N/A |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Enable easy migration of classnames, updates both
phpcr:class and phpcr:parentclass fields.

Note is very little testing in this bundle, the tests that do exist are not travis aware and one of them requires a non-existing dev requirement (LiipFunctionalTestBundle).

This command should have a test to ensure that we don't get regressions when phpcr-utils changes, but this is difficult without serious bootstrapping.
