### PR TITLE
deprecate the phpcr_odm_reference_collection form type in favor of phpcr_document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2013-12-11**: [Form] Deprecated the form type "phpcr_odm_reference_collection".
+  It seems to not work and "phpcr_document" should cover everything we need.
+
 * **2013-11-27**: [Initializer] Parameter "doctrine_phpcr.initialize.initializers" no longer defined
  * Initializers are now collected using a compiler pass and injected into the new InitializerManager
 * **2013-11-27**: [Initializer] `doctrine:phpcr:fixtures:load` now executes all of the initializers

--- a/Form/DataTransformer/ReferenceManyCollectionToArrayTransformer.php
+++ b/Form/DataTransformer/ReferenceManyCollectionToArrayTransformer.php
@@ -6,6 +6,10 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Doctrine\ODM\PHPCR\ReferenceManyCollection;
 use Doctrine\ODM\PHPCR\DocumentManager;
 
+/**
+ * @deprecated This is only used by the deprecated PHPCRODMReferenceCollectionType.
+ *      Will be removed in 1.2.
+ */
 class ReferenceManyCollectionToArrayTransformer implements DataTransformerInterface
 {
     const KEY_PATH = 'path';
@@ -34,6 +38,8 @@ class ReferenceManyCollectionToArrayTransformer implements DataTransformerInterf
      */
     function __construct(DocumentManager $dm, $referencedClass, $key = self::KEY_UUID)
     {
+        trigger_error('This is deprecated in favor of phpcr_document. If you think this is an error, please contact us and explain. We where not able to figure out what this type is good for.', E_WARNING);
+
         $this->dm = $dm;
         $this->referencedClass = $referencedClass;
 

--- a/Form/Type/PHPCRODMReferenceCollectionType.php
+++ b/Form/Type/PHPCRODMReferenceCollectionType.php
@@ -10,6 +10,9 @@ use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\ReferenceManyCollectionToAr
 
 /**
  * A type to handle a list of references as simple choice.
+ *
+ * @deprecated This seems to do nothing more than the DocumentType.
+ *      Will be removed in 1.2.
  */
 class PHPCRODMReferenceCollectionType extends AbstractType
 {
@@ -59,6 +62,8 @@ class PHPCRODMReferenceCollectionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        trigger_error('This form type is deprecated in favor of phpcr_document. If you think this is an error, please contact us and explain. We where not able to figure out what this type is good for.', E_WARNING);
+
         $transformer = new ReferenceManyCollectionToArrayTransformer($this->dm, $options['referenced_class'], $options['key']);
         $builder->addModelTransformer($transformer);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | relates to https://github.com/symfony-cmf/symfony-cmf-docs/pull/347 |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/351 |

afaict this form type does not even work (anymore?) and it seems the only thing it does that phpcr_document can not do better already is to allow to use the UUID instead of the path (as path is the primary id for phpcr-odm). not sure if that is worth anything - but if so we should port that into the phpcr_document type.

if we deprecate this now, would we drop it in version 1.2? i _think_ this is not even usable, but i might be wrong so we could use the deprecation to hear from users.
