### PR TITLE
[WIP] update fallback locales based on request

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -132,6 +132,7 @@ class Configuration implements ConfigurationInterface
                                 'auto_generate_proxy_classes' => true,
                                 'proxy_dir' => true,
                                 'proxy_namespace' => true,
+                                'locale_fallback' => true,
                                 'locales' => true,
                             );
                             $documentManagers = array();
@@ -153,6 +154,10 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('auto_generate_proxy_classes')->defaultFalse()->end()
                         ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/PHPCRProxies')->end()
                         ->scalarNode('proxy_namespace')->defaultValue('PHPCRProxies')->end()
+                        ->enumNode('locale_fallback')
+                            ->values(array('hardcoded', 'merge', 'replace'))
+                            ->defaultValue('hardcoded')
+                        ->end()
                     ->end()
                     ->fixXmlConfig('document_manager')
                     ->append($this->getOdmDocumentManagersNode())

--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -324,7 +324,9 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
             }
 
             $container->setParameter('doctrine_phpcr.odm.locales', $config['locales']);
+            $container->setParameter('doctrine_phpcr.odm.allowed_locales', array_keys($config['locales']));
             $container->setParameter('doctrine_phpcr.odm.default_locale', key($config['locales']));
+            $container->setParameter('doctrine_phpcr.odm.locale_fallback', $config['locale_fallback'] == 'hardcoded' ? null : $config['locale_fallback']);
 
             $dm = $container->getDefinition('doctrine_phpcr.odm.document_manager.abstract');
             $dm->addMethodCall('setLocaleChooserStrategy', array(new Reference('doctrine_phpcr.odm.locale_chooser')));

--- a/Resources/config/odm_multilang.xml
+++ b/Resources/config/odm_multilang.xml
@@ -19,6 +19,8 @@
         <service id="doctrine_phpcr.odm.locale_listener" class="%doctrine_phpcr.odm.locale_listener.class%">
             <tag name="kernel.event_subscriber"/>
             <argument type="service" id="doctrine_phpcr.odm.locale_chooser"/>
+            <argument>%doctrine_phpcr.odm.allowed_locales%</argument>
+            <argument>%doctrine_phpcr.odm.locale_fallback%</argument>
         </service>
 
     </services>


### PR DESCRIPTION
fix #44 , depends on https://github.com/doctrine/phpcr-odm/pull/445

there is an additional configuration option

```
doctrine_phpcr:
  odm:
    locale_fallback: hardcoded
    locales:
        en:
            - de
            - fr
        de:
            - en
            - fr
        fr:
            - en
            - de
```
- the fallback mode can be hardcoded (do not do anything based on request) or merge to prepend the request locales, or replace to replace the configured language order with the request information.
