### PR TITLE
allow initializers to run even when phpcr-odm is not present

### DIFF
--- a/DoctrinePHPCRBundle.php
+++ b/DoctrinePHPCRBundle.php
@@ -33,7 +33,6 @@ use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\InitializerPass;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\InitDoctrineDbalCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\JackrabbitCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\InfoDoctrineCommand;
-use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\RepositoryInitCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\DocumentMigrateClassCommand;
 
 class DoctrinePHPCRBundle extends Bundle
@@ -58,7 +57,6 @@ class DoctrinePHPCRBundle extends Bundle
 
         if (class_exists('Doctrine\ODM\PHPCR\Version')) {
             $application->add(new InfoDoctrineCommand());
-            $application->add(new RepositoryInitCommand());
             $application->add(new DocumentMigrateClassCommand());
         }
 

--- a/Initializer/InitializerInterface.php
+++ b/Initializer/InitializerInterface.php
@@ -39,7 +39,7 @@ interface InitializerInterface
     public function init(ManagerRegistry $registry);
 
     /**
-     * Return a name which can be used to identify this intializer.
+     * Return a name which can be used to identify this initializer.
      *
      * @return string
      */

--- a/Initializer/InitializerManager.php
+++ b/Initializer/InitializerManager.php
@@ -76,10 +76,7 @@ class InitializerManager
     }
 
     /**
-     * Iterate over the registered initializers and execute init
-     * on each.
-     *
-     * @param string $sessionName
+     * Iterate over the registered initializers and execute each of them.
      */
     public function initialize()
     {


### PR DESCRIPTION
fix #83 

test coverage is probably not that big, but i tested things locally and we still execute both parts when we have phpcr-odm present. and we will quickly see on travis if we broke something.

i fear there might be other places where we fail if phpcr-odm is not present - ideally we would have a test suite that we could run on travis without having phpcr-odm installed.
