### PR TITLE
Package phpcr/phpcr-implementation not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.2",
         "symfony/doctrine-bridge": "~2.2",
-        "phpcr/phpcr-implementation": "2.1.*",
+        "phpcr/phpcr": "2.1.*",
         "phpcr/phpcr-utils": "~1.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi, 

the package was rename or move however it is still in the [composer.json](https://github.com/doctrine/DoctrinePHPCRBundle/blob/master/composer.json#L23)
