### PR TITLE
remove testing BC code now that 2.2 is gone

### DIFF
--- a/Tests/Functional/Form/PHPCRTypeGuesserTest.php
+++ b/Tests/Functional/Form/PHPCRTypeGuesserTest.php
@@ -355,12 +355,7 @@ class PHPCRTypeGuesserTest extends BaseTestCase
     {
         $formView = $formBuilder->getForm()->createView();
         $templating = $this->getContainer()->get('templating');
-        // there was a BC break in symfony2 form rendering between 2.2 and 2.3
-        $template = version_compare(Kernel::VERSION, '2.3.0') < 0
-            ? '::form22.html.twig'
-            : '::form.html.twig'
-        ;
-        $templating->render($template, array('form' => $formView));
+        $templating->render('::form.html.twig', array('form' => $formView));
     }
 
     /**

--- a/Tests/Resources/app/Resources/views/form22.html.twig
+++ b/Tests/Resources/app/Resources/views/form22.html.twig
@@ -1,1 +1,0 @@
-{{ form_widget(form) }}


### PR DESCRIPTION
found some leftover BC code in the tests.
