### PR TITLE
fix multi session support

### DIFF
--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -20,6 +20,7 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -243,6 +244,9 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         foreach ($session['options'] as $key => $value) {
             $definition->addMethodCall('setSessionOption', array($key, $value));
         }
+
+        $eventManagerServiceId = sprintf('doctrine_phpcr.%s_session.event_manager', $session['name']);
+        $container->setDefinition($eventManagerServiceId, new DefinitionDecorator('doctrine_phpcr.session.event_manager'));
     }
 
     private function loadMidgard2Session(array $session, ContainerBuilder $container)
@@ -383,15 +387,12 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
             throw new InvalidArgumentException(sprintf("You have configured a non existent session '%s' for the document manager '%s'", $documentManager['session'], $documentManager['name']));
         }
 
-        $eventManagerServiceId = sprintf('doctrine_phpcr.odm.%s_session.event_manager', $documentManager['session']);
-        $container->setDefinition($eventManagerServiceId, new DefinitionDecorator('doctrine_phpcr.odm.document_manager.event_manager'));
-
         $container
             ->setDefinition($documentManager['service_name'], new DefinitionDecorator('doctrine_phpcr.odm.document_manager.abstract'))
             ->setArguments(array(
                 new Reference(sprintf('doctrine_phpcr.%s_session', $documentManager['session'])),
                 new Reference(sprintf('doctrine_phpcr.odm.%s_configuration', $documentManager['name'])),
-                new Reference($eventManagerServiceId)
+                new Reference(sprintf('doctrine_phpcr.%s_session.event_manager', $documentManager['session']))
             ))
         ;
     }

--- a/DoctrinePHPCRBundle.php
+++ b/DoctrinePHPCRBundle.php
@@ -44,7 +44,7 @@ class DoctrinePHPCRBundle extends Bundle
         $container->addCompilerPass(new MigratorPass());
         $container->addCompilerPass(new InitializerPass());
         if (class_exists('Doctrine\ODM\PHPCR\Version')) {
-            $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine_phpcr.sessions', 'doctrine_phpcr.odm.%s_session.event_manager', 'doctrine_phpcr'), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+            $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass('doctrine_phpcr.sessions', 'doctrine_phpcr.%s_session.event_manager', 'doctrine_phpcr'), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         }
     }
 

--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -8,7 +8,6 @@
 
         <parameter key="doctrine_phpcr.odm.configuration.class">Doctrine\ODM\PHPCR\Configuration</parameter>
         <parameter key="doctrine_phpcr.odm.document_manager.class">Doctrine\ODM\PHPCR\DocumentManager</parameter>
-        <parameter key="doctrine_phpcr.odm.document_manager.event_manager.class">Symfony\Bridge\Doctrine\ContainerAwareEventManager</parameter>
 
         <!-- cache -->
         <parameter key="doctrine_phpcr.odm.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
@@ -57,10 +56,6 @@
             class="%doctrine_phpcr.odm.document_manager.class%"
             abstract="true"
         />
-
-        <service id="doctrine_phpcr.odm.document_manager.event_manager" class="%doctrine_phpcr.odm.document_manager.event_manager.class%" public="false" abstract="true">
-            <argument type="service" id="service_container"/>
-        </service>
 
         <service id="form.type.phpcr_odm.reference_collection" class="Doctrine\Bundle\PHPCRBundle\Form\Type\PHPCRODMReferenceCollectionType">
             <tag name="form.type" alias="phpcr_odm_reference_collection"/>

--- a/Resources/config/phpcr.xml
+++ b/Resources/config/phpcr.xml
@@ -23,9 +23,16 @@
         <parameter key="doctrine_phpcr.logger.stop_watch.class">Doctrine\Bundle\PHPCRBundle\DataCollector\StopWatchLogger</parameter>
         <parameter key="doctrine_phpcr.data_collector.class">Doctrine\Bundle\PHPCRBundle\DataCollector\PHPCRDataCollector</parameter>
 
+        <parameter key="doctrine_phpcr.session.event_manager.class">Symfony\Bridge\Doctrine\ContainerAwareEventManager</parameter>
+
     </parameters>
 
     <services>
+
+        <service id="doctrine_phpcr.session.event_manager" class="%doctrine_phpcr.session.event_manager.class%" public="false" abstract="true">
+            <argument type="service" id="service_container"/>
+        </service>
+
         <service id="doctrine_phpcr.logger.chain" class="%doctrine_phpcr.logger.chain.class%" public="false" abstract="true">
             <call method="addLogger">
                 <argument type="service" id="doctrine_phpcr.logger" />

--- a/Tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
@@ -54,6 +54,39 @@ class DoctrinePHPCRExtensionTest extends AbstractExtensionTestCase
         $this->assertEquals('doctrine_phpcr.jackalope.repository.factory.jackrabbit', $repositoryFactory->getParent());
     }
 
+    public function testJackrabbitSessions()
+    {
+        $this->load(array(
+            'session' => array(
+                'default_session' => 'bar',
+                'sessions' => array(
+                    'foo' => array(
+                        'backend' => array(
+                            'url' => 'http://foo',
+                        ),
+                        'workspace' => 'default',
+                        'username' => 'admin',
+                        'password' => 'admin',
+                    ),
+                    'bar' => array(
+                        'backend' => array(
+                            'url' => 'http://bar',
+                        ),
+                        'workspace' => 'default',
+                        'username' => 'admin',
+                        'password' => 'admin',
+                    ),
+                )
+            ),
+        ));
+
+        $this->assertCount(2, $this->container->getParameter('doctrine_phpcr.sessions'));
+
+        foreach ($this->container->getParameter('doctrine_phpcr.sessions') as $id) {
+            $this->container->getDefinition($id);
+        }
+    }
+
     public function testDoctrineDbalSession()
     {
         $this->load(array(


### PR DESCRIPTION
fix #140 

the issue is caused by `RegisterEventListenersAndSubscribersPass` in the doctrine bridge. I think we incorrectly only created the event_manager for the session associated with the ODM. as a result I also renamed the service though that might be a BC break we rather not have .. or maybe we should have an alias for the old service name?

we also need a test case for multi session
