### PR TITLE
[POC] [PCM] Allow automatic of node types loading from bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/framework-bundle": "~2.3",
         "symfony/doctrine-bridge": "~2.3",
         "phpcr/phpcr-implementation": "2.1.*",
-        "phpcr/phpcr-utils": "~1.1.0"
+        "phpcr/phpcr-utils": "~1.2.0"
     },
     "require-dev": {
         "symfony/form": "~2.2",


### PR DESCRIPTION
This PR adds support for automatically loading node type definitions from bundles, just like doctrine schemas.
- The node type files must be located in `Resources/config/phpcr-node-types`
- There is no bundle white / black list, if the folder exists and it contains node types, then they are loaded for _all_ registered bundles

I don't _think_ its a problem if we always load all node types from all registered bundles, after all, each node type file should be using its own namespace.

This PR builds uses https://github.com/phpcr/phpcr-utils/pull/108

Usage:

Load all node types from all bundles: (this PR)

``` bash
$ php app/console doctrine:phpcr:node-type:register --allow-update
```

Load from individual folders or files: (phpcr-utils PR)

``` bash
$ php app/console doctrine:phpcr:node-type:register --target=foobar/barfoo.cnd --target=src/MyBundle/mynodetypefolder
```
