### PR TITLE
define xml namespace for DI configuration

### DIFF
--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -50,6 +50,9 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
     /** @var XmlFileLoader */
     private $loader;
 
+    /**
+     * {@inheritDoc}
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $processor = new Processor();
@@ -401,6 +404,9 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         ;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingDriverBundleConfigDefaults(array $bundleConfig, \ReflectionClass $bundle, ContainerBuilder $container)
     {
         $this->bundleDirs[] = dirname($bundle->getFileName());
@@ -445,23 +451,43 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         $this->loadObjectManagerCacheDriver($documentManager, $container, 'metadata_cache');
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getObjectManagerElementName($name)
     {
         return 'doctrine_phpcr.odm.'.$name;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingObjectDefaultName()
     {
         return 'Document';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingResourceConfigDirectory()
     {
         return 'Resources/config/doctrine';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingResourceExtension()
     {
         return 'phpcr';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNamespace()
+    {
+        return 'http://doctrine-project.org/schema/symfony-dic/odm/phpcr';
     }
 }

--- a/Tests/Resources/Fixtures/config/multiple.xml
+++ b/Tests/Resources/Fixtures/config/multiple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container xmlns="http://symfony.com/schema/dic/services">
-    <config xmlns="http://example.org/schema/dic/doctrine_phpcr">
+    <config xmlns="http://doctrine-project.org/schema/symfony-dic/odm/phpcr">
         <session>
             <session name="default"
                      workspace="default"

--- a/Tests/Resources/Fixtures/config/single.xml
+++ b/Tests/Resources/Fixtures/config/single.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container xmlns="http://symfony.com/schema/dic/services">
 
-    <config xmlns="http://example.org/schema/dic/doctrine_phpcr"
+    <config xmlns="http://doctrine-project.org/schema/symfony-dic/odm/phpcr"
         jackrabbit_jar="/path/to/jackrabbit.jar"
         dump_max_line_length="20"
     >


### PR DESCRIPTION
going with the proposal from stof. this is half-consistent with https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/DependencyInjection/DoctrineMongoDBExtension.php#L362 . the couch bundle has no namespace declaration.

fix #132
