### PR TITLE
removed fixXmlConfig for caches node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -151,7 +151,6 @@ class Configuration implements ConfigurationInterface
                             })
                         ->end()
                         ->fixXmlConfig('parameter')
-                        ->fixXmlConfig('cache')
                         ->children()
                             ->enumNode('type')
                                 ->values(array('jackrabbit', 'doctrinedbal', 'prismic', 'midgard2'))


### PR DESCRIPTION
The caches node is not a protyped array, thus it should not have a singular version
