### PR TITLE
Embedded PHPCR Shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2014-08-09**: Added PHPCR-Shell proxy command. This command deprecates the existing 
+  PHPCR commands and provides access to the full suite of commands provided by PHPCR shell.
+
 * **2014-07-25**: jackalope.check_login_on_server now defaults to kernel.debug.
   Furthermore Proxy cache warming is disabled when jackalope.check_login_on_server
   is enabled and Jackalope Doctrine DBAL is used by any Document Manager

--- a/Command/NodeTouchCommand.php
+++ b/Command/NodeTouchCommand.php
@@ -60,4 +60,3 @@ class NodeTouchCommand extends BaseNodeTouchCommand
         return parent::execute($input, $output);
     }
 }
-

--- a/Command/NodeTypeListCommand.php
+++ b/Command/NodeTypeListCommand.php
@@ -60,5 +60,3 @@ class NodeTypeListCommand extends BaseTypeListCommand
         return parent::execute($input, $output);
     }
 }
-
-

--- a/Command/PhpcrShellCommand.php
+++ b/Command/PhpcrShellCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\PHPCRBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use PHPCR\Shell\Console\Application\EmbeddedApplication;
+use Symfony\Component\Console\Input\ArgvInput;
+use PHPCR\Shell\Console\Input\StringInput;
+use PHPCR\Shell\PhpcrSession;
+use Symfony\Component\Console\Input\InputArgument;
+use PHPCR\Shell\Console\Application\Shell;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+/**
+ * Wrapper to use this command in the symfony console with multiple sessions.
+ */
+class PhpcrShellCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this->setName('doctrine:phpcr:shell');
+        $this->addArgument('cmd', InputArgument::IS_ARRAY);
+        $this->addOption('session', null, InputOption::VALUE_OPTIONAL, 'The session to use for this command');
+        $this->setDescription('Proxy for an embedded PHPCR Shell. Commands should be quoted');
+        $this->setHelp(<<<EOT
+This command will send commands to an embedded PHPCR shell. For it to work you
+will need to have the phpcr-shell dependency installed.
+
+To list the available sub-commands:
+
+    <info>$ %command.full_name%</info>
+
+Simple commands can be executed as follows:
+
+    <info>$ %command.full_name% node:list</info>
+    <info>$ %command.full_name% node:create foobar my:nodetype</info>
+    <info>$ %command.full_name% session:namespace:set foo http://foobar.com/foo</info>
+
+Due to limitations with the Symfony Console component, if you want to specify
+options you will need to quote the entire sub-command:
+
+    <info>$ %command.full_name% "node:list /path/to/some/node --level=3 --template"</info>
+
+You can execute SELECT JCR-SQL2 queries as follows:
+
+    <info>$ php app/console phpcr "SELECT * FROM [nt:unstructured]"</info>
+
+NOTE: When executing single commands the session is saved automatically. This
+      is in contrast to the shell, where the session has to be explicitly saved with
+      the <info>session:save</info> command.
+EOT
+    );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!class_exists('PHPCR\Shell\Console\Application\SessionApplication')) {
+            throw new \InvalidArgumentException(sprintf(
+                'PHPCR-Shell not installed as a dependency. Add the "phpcr/phpcr-shell" to your ' .
+                'composer.json file to use this command'
+            ));
+        }
+
+        DoctrineCommandHelper::setApplicationPHPCRSession(
+            $this->getApplication(),
+            $input->getOption('session')
+        );
+
+        $args = $input->getArgument('cmd');
+        $mode = empty($args) ? EmbeddedApplication::MODE_SHELL : EmbeddedApplication::MODE_COMMAND;
+        $session = $this->getHelper('phpcr')->getSession();
+
+        $application = new EmbeddedApplication($mode);
+        $application->getHelperSet()->get('phpcr')->setSession(new PhpcrSession($session));
+
+        // If no arguments supplied, launch the shell with the embedded application
+        if ($mode === EmbeddedApplication::MODE_SHELL) {
+            $shell = new Shell($application);
+            $shell->run();
+        } else {
+            // else try and run the command using the given input
+            $application->run(new StringInput(implode(' ', $args), $output));
+            $session->save();
+        }
+    }
+}

--- a/Command/WorkspacePurgeCommand.php
+++ b/Command/WorkspacePurgeCommand.php
@@ -60,4 +60,3 @@ class WorkspacePurgeCommand extends BaseWorkspacePurgeCommand
         return parent::execute($input, $output);
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "0.*"
     },
     "suggest": {
+        "phpcr/phpcr-shell": "If you want native access to PHPCR-Shell to manage the PHPCR repository",
         "doctrine/phpcr-odm": "if you want to use the odm as well. require version 1.1.*",
         "jackalope/jackalope-jackrabbit": "if you want to connect to jackrabbit. require version ~1.0.1",
         "jackalope/jackalope-doctrine-dbal": "if you want to use jackalope-doctrine-dbal. require version 1.0.*",


### PR DESCRIPTION
Replaces existing commands with embedded PHPCR Shell.

Depends on: https://github.com/phpcr/phpcr-shell/pull/40

For example

```
$ php app/console doctrine:phpcr:shell node:list / # commands with arguments can be entered without quotes
$ php app/console doctrine:phpcr:shell "ls -L2" # commands with options must be quoted
$ php app/console doctrine:phpcr:shell node-type:list
$ php app/console doctrine:phpcr:shell "SELECT * FROM [nt:unstructured]" # queries must be quoted
```

Or launch a shell session

```
$php app/console doctrine:phpcr:shell
```
