### PR TITLE
fix Jackalope session factory config to work again

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -157,6 +157,7 @@ class Configuration implements ConfigurationInterface
                                 ->defaultValue('jackrabbit')
                             ->end()
                             // all jackalope
+                            ->scalarNode('factory')->defaultNull()->end()
                             ->booleanNode('logging')->defaultFalse()->end()
                             ->booleanNode('profiling')->defaultFalse()->end()
                             ->arrayNode('parameters')

--- a/Tests/Resources/Fixtures/config/multiple.php
+++ b/Tests/Resources/Fixtures/config/multiple.php
@@ -15,6 +15,7 @@ $container->loadFromExtension('doctrine_phpcr', array(
                 'backend' => array(
                     'type' => 'jackrabbit',
                     'url' => 'http://b',
+                    'factory' => null,
                 ),
                 'workspace' => 'website',
                 'username' => 'root',

--- a/Tests/Resources/Fixtures/config/single.php
+++ b/Tests/Resources/Fixtures/config/single.php
@@ -7,6 +7,7 @@ $container->loadFromExtension('doctrine_phpcr', array(
             'url' => 'http://localhost:8080/server/',
             'logging' => true,
             'profiling' => true,
+            'factory' => null,
             'parameters' => array(
                 'jackalope.factory' => 'Jackalope\Factory',
                 'jackalope.check_login_on_server' => false,

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -53,6 +53,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             'type' => 'jackrabbit',
                             'logging' => true,
                             'profiling' => true,
+                            'factory' => null,
                             'parameters' => array(
                                 'jackalope.factory' => 'Jackalope\Factory',
                                 'jackalope.check_login_on_server' => false,
@@ -122,6 +123,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             'type' => 'jackrabbit',
                             'logging' => false,
                             'profiling' => false,
+                            'factory' => null,
                             'parameters' => array(
                             ),
                             'url' => 'http://a',
@@ -140,6 +142,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             'parameters' => array(
                             ),
                             'url' => 'http://b',
+                            'factory' => null,
                         ),
                         'workspace' => 'website',
                         'username' => 'root',
@@ -201,6 +204,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             'type' => 'doctrinedbal',
                             'logging' => false,
                             'profiling' => false,
+                            'factory' => null,
                             'parameters' => array(
                                 'jackalope.factory' => 'Jackalope\Factory',
                                 'jackalope.check_login_on_server' => true,

--- a/Tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
@@ -95,8 +95,8 @@ class DoctrinePHPCRExtensionTest extends AbstractExtensionTestCase
                     'type' => 'doctrinedbal',
                     'logging' => true,
                     'profiling' => true,
+                    'factory' => 'my_factory',
                     'parameters' => array(
-                        'jackalope.factory' => 'Jackalope\Factory',
                         'jackalope.check_login_on_server' => false,
                         'jackalope.disable_stream_wrapper' => false,
                         'jackalope.auto_lastmodified' => true,
@@ -117,12 +117,15 @@ class DoctrinePHPCRExtensionTest extends AbstractExtensionTestCase
         $this->assertInternalType('array', $parameters);
         $this->assertEquals(array(
             'jackalope.doctrine_dbal_connection',
-            'jackalope.factory',
             'jackalope.check_login_on_server',
             'jackalope.disable_stream_wrapper',
             'jackalope.auto_lastmodified',
+            'jackalope.factory',
             'jackalope.logger',
         ), array_keys($parameters));
+
+        $this->assertEquals('my_factory', (string) $parameters['jackalope.factory']);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $parameters['jackalope.factory']);
 
         $this->assertEquals('doctrine_phpcr.jackalope.repository.factory.doctrinedbal', $repositoryFactory->getParent());
 


### PR DESCRIPTION
should be released as 1.1.1 and then needs to be merged to master afterwards

fix for https://github.com/doctrine/DoctrinePHPCRBundle/issues/160
