### PR TITLE
rename PHPCRTypeGuesser to PhpcrOdmTypeGuesser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 Changelog
 =========
 
-* **2014-08-09**: Added PHPCR-Shell proxy command. This command deprecates the existing 
+* **2014-08-19**: Renamed PHPCRTypeGuesser to PhpcrOdmTypeGuesser as its about phpcr-odm.
+
+* **2014-08-09**: Added PHPCR-Shell proxy command. This command deprecates the existing
   PHPCR commands and provides access to the full suite of commands provided by PHPCR shell.
 
 * **2014-07-25**: jackalope.check_login_on_server now defaults to kernel.debug.

--- a/Form/DoctrinePHPCRExtension.php
+++ b/Form/DoctrinePHPCRExtension.php
@@ -32,6 +32,6 @@ class DoctrinePHPCRExtension extends AbstractExtension
 
     protected function loadTypeGuesser()
     {
-        return new PHPCRTypeGuesser($this->registry);
+        return new PhpcrOdmTypeGuesser($this->registry);
     }
 }

--- a/Form/PhpcrOdmTypeGuesser.php
+++ b/Form/PhpcrOdmTypeGuesser.php
@@ -33,7 +33,7 @@ use Symfony\Component\Form\Guess\ValueGuess;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class PHPCRTypeGuesser implements FormTypeGuesserInterface
+class PhpcrOdmTypeGuesser implements FormTypeGuesserInterface
 {
     /**
      * @var ManagerRegistry

--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -19,7 +19,7 @@
         <parameter key="doctrine_phpcr.odm.cache.xcache.class">Doctrine\Common\Cache\XcacheCache</parameter>
 
         <!-- form field factory guesser -->
-        <parameter key="form.type_guesser.doctrine_phpcr.class">Doctrine\Bundle\PHPCRBundle\Form\PHPCRTypeGuesser</parameter>
+        <parameter key="form.type_guesser.doctrine_phpcr.class">Doctrine\Bundle\PHPCRBundle\Form\PhpcrOdmTypeGuesser</parameter>
 
         <parameter key="doctrine_phpcr.odm.form.path.type.class">Doctrine\Bundle\PHPCRBundle\Form\Type\PathType</parameter>
 

--- a/Tests/Functional/Form/PHPCRTypeGuesserTest.php
+++ b/Tests/Functional/Form/PHPCRTypeGuesserTest.php
@@ -11,7 +11,7 @@ use Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument;
 use Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\ReferrerDocument;
 use Symfony\Component\HttpKernel\Kernel;
 
-class PHPCRTypeGuesserTest extends BaseTestCase
+class PhpcrOdmTypeGuesserTest extends BaseTestCase
 {
     /**
      * @var TestDocument


### PR DESCRIPTION
fix #155

i propose to use PhpcrOdmTypeGuesser as PHPCRODMTypeGuesser would look horrible, and its consistent with https://github.com/doctrine/DoctrinePHPCRBundle/blob/master/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php for example. (though admittedly there are some classes starting with PHPCRODM)

while looking at this, i noticed https://github.com/doctrine/DoctrinePHPCRBundle/blob/master/Form/DoctrinePHPCRExtension.php . i fixed a BC break in the type guesser that started requiring the assoc options. DoctrinePHPCRExtension is never used anywhere, and there is no service for it. what is it good for? it seems not needed for the form layer to work: https://github.com/doctrine/DoctrinePHPCRBundle/blob/master/Tests/Functional/Form/PHPCRTypeGuesserTest.php
