### PR TITLE
Extensibility

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -86,6 +86,23 @@ class LocaleListener implements EventSubscriberInterface
     }
 
     /**
+     * Decides which locale will be used.
+     *
+     * @param GetResponseEvent $event used to get the request
+     *
+     * @return mixed string|false a locale or false it cannot be found in the
+     *                            array of allowed locales
+     */
+    protected function determineLocale(GetResponseEvent $event)
+    {
+        $locale = $event->getRequest()->getLocale();
+
+        return in_array($locale, $this->allowedLocales) ?
+            $locale:
+            false;
+    }
+
+    /**
      * Handling the request event
      *
      * @param GetResponseEvent $event
@@ -93,10 +110,11 @@ class LocaleListener implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        $locale = $request->getLocale();
-        if (!in_array($locale, $this->allowedLocales)) {
+
+        if (!$locale = $this->determineLocale($event)) {
             return;
         }
+
         $this->chooser->setLocale($locale);
 
         if (self::FALLBACK_HARDCODED == $this->fallback) {

--- a/Tests/Unit/EventListener/LocaleListenerTest.php
+++ b/Tests/Unit/EventListener/LocaleListenerTest.php
@@ -44,7 +44,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
             LocaleListener::FALLBACK_HARDCODED
         );
 
-        $this->responseEvent->expects($this->exactly(2))
+        $this->responseEvent->expects($this->exactly(4))
             ->method('getRequest')
             ->will($this->returnValue($this->request));
 
@@ -70,7 +70,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
             LocaleListener::FALLBACK_REPLACE
         );
 
-        $this->responseEvent->expects($this->once())
+        $this->responseEvent->expects($this->exactly(2))
             ->method('getRequest')
             ->will($this->returnValue($this->request));
 


### PR DESCRIPTION
Using `private` visibility when creating classes in a library prevents easy code reuse. For instance, in our project, we decided to use the `locale` parameter for the UI, and use another parameter (named `content_locale`) for the content. On one of our website, there will be 2 UI languages, and 4 content langauges (it is an administration interface for a swiss project). We need to have another listener, but the developer in charge of this did not extend your class because he needed to rewrite the same properties because they were private. It's a shame, and it is not the first time this scenario happens to me. I think it calls for a (new ?) best practice : 

> When writing library code, try to avoid `private` .

Do you agree ?
