### PR TITLE
Show the name of the API call in addition to the parameters and timings

### DIFF
--- a/Resources/views/Collector/phpcr.html.twig
+++ b/Resources/views/Collector/phpcr.html.twig
@@ -64,6 +64,7 @@
                                 {{ call.method|raw }}
                             </code>
                             <small>
+                                <strong>Method</strong>: {{ call.method|yaml_encode }} <br />
                                 <strong>Parameters</strong>: {{ call.params|yaml_encode }} <br />
                                 <strong>Environment</strong>: {{ call.env|yaml_encode }} <br />
                             </small>


### PR DESCRIPTION
For some reason the `method` of the API call was being collected but not shown in the profiler.
