### PR TITLE
Changed PHPCR Shell instantiation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "doctrine/doctrine-bundle": "when using jackalope-doctrine-dbal",
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*"
     },
+    "conflict": {
+        "phpcr/phpcr-shell": "<1.0.0-beta1"
+    },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\PHPCRBundle\\": "" }
     },


### PR DESCRIPTION
The way PHPCRSH is instantiated has changed as of 1.0 and I don't want to have a bunch of legacy code for alpha BC in the stable release, so this is a BC break with existing behavior for the alpha version.

This is (still) a suggested dependency, people who have installed the phpcr-shell will simply need to perform a minor upgrade.

Note this depends on the 1.0 release of [PHPCRSH](https://github.com/phpcr/phpcr-shell)