### PR TITLE
Enable locale namespace alias to be configured

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Doctrine\ODM\PHPCR\Translation\Translation;
 
 /**
  * Configuration for the PHPCR extension
@@ -240,6 +241,17 @@ class Configuration implements ConfigurationInterface
                         ->enumNode('locale_fallback')
                             ->values(array('hardcoded', 'merge', 'replace'))
                             ->defaultValue('hardcoded')
+                        ->end()
+                        ->arrayNode('namespaces')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->arrayNode('translation')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('alias')->defaultValue(Translation::LOCALE_NAMESPACE)->end()
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                     ->fixXmlConfig('document_manager')

--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -9,6 +9,10 @@
         <parameter key="doctrine_phpcr.odm.configuration.class">Doctrine\ODM\PHPCR\Configuration</parameter>
         <parameter key="doctrine_phpcr.odm.document_manager.class">Doctrine\ODM\PHPCR\DocumentManager</parameter>
 
+        <!-- Translation strategies -->
+        <parameter key="doctrine_phpcr.odm.translation.strategy.attribute.class">Doctrine\ODM\PHPCR\Translation\TranslationStrategy\AttributeTranslationStrategy</parameter>
+        <parameter key="doctrine_phpcr.odm.translation.strategy.child.class">Doctrine\ODM\PHPCR\Translation\TranslationStrategy\ChildTranslationStrategy</parameter>
+
         <!-- cache -->
         <parameter key="doctrine_phpcr.odm.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>
         <parameter key="doctrine_phpcr.odm.cache.apc.class">Doctrine\Common\Cache\ApcCache</parameter>
@@ -85,6 +89,18 @@
         <service id="doctrine_phpcr.odm.validator.valid_phpcr_odm" class="%doctrine_phpcr.odm.validator.valid_phpcr_odm.class%">
             <argument type="service" id="doctrine_phpcr" />
             <tag name="validator.constraint_validator" alias="doctrine_phpcr.odm.validator.valid_phpcr_odm"/>
+        </service>
+
+        <!-- Translation strategies -->
+        <service id="doctrine_phpcr.odm.translation.strategy.attribute" class="%doctrine_phpcr.odm.translation.strategy.attribute.class%">
+            <argument />
+            <call method="setPrefix">
+                <argument>%doctrine_phpcr.odm.namespaces.translation.alias%</argument>
+            </call>
+        </service>
+
+        <service id="doctrine_phpcr.odm.translation.strategy.child" class="%doctrine_phpcr.odm.translation.strategy.child.class%">
+            <argument />
         </service>
 
     </services>

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -112,6 +112,11 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'repository_factory' => null,
                     ),
                 ),
+                'namespaces' => array(
+                    'translation' => array(
+                        'alias' => 'phpcr_locale',
+                    ),
+                ),
             ),
             'jackrabbit_jar' => '/path/to/jackrabbit.jar',
             'dump_max_line_length' => 20,
@@ -194,6 +199,11 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'repository_factory' => null,
                         'session' => 'website',
                         'configuration_id' => 'sandbox_magnolia.odm_configuration',
+                    ),
+                ),
+                'namespaces' => array(
+                    'translation' => array(
+                        'alias' => 'phpcr_locale'
                     ),
                 ),
             ),


### PR DESCRIPTION
This PR allows the namespace alias used for the attribute translation strategy to be configured.

It also adds the translation strategies to the DI container, which paves the way for dynamically registering new strategies in the future if required.

See documentation PR: https://github.com/symfony-cmf/symfony-cmf-docs/pull/653