### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - hhvm
 
 env:
-  - SYMFONY_VERSION=2.6.*
+  - SYMFONY_VERSION="~2.3||~3.0"
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.3.27 || ~2.6.6 || ~2.7",
-        "symfony/doctrine-bridge": "~2.3",
+        "symfony/framework-bundle": "~2.3.27 || ~2.6.6 || ~2.7 || ~3.0",
+        "symfony/doctrine-bridge": "~2.3 || ~3.0",
         "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "~1.2.0"
     },
     "require-dev": {
-        "symfony/form": "~2.2",
+        "symfony/form": "~2.3 || ~3.0",
         "doctrine/phpcr-odm": "~1.3",
         "jackalope/jackalope-jackrabbit": "~1.1.0",
         "symfony-cmf/testing": "~1.1",


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0