### PR TITLE
[Form] Fix DocumentType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,11 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION=2.3.*
     - php: 5.5
-      env: SYMFONY_VERSION=2.4.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.5
       env: SYMFONY_VERSION=2.7.* SYMFONY_DEPRECATIONS_HELPER=weak
 
 before_install:
   - composer self-update || true
+  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
   - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
   - COMPOSER_ROOT_VERSION=dev-master composer update $COMPOSER_FLAGS --prefer-source --no-interaction
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -18,7 +18,6 @@ namespace Doctrine\Bundle\PHPCRBundle\Form\Type;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Bundle\PHPCRBundle\Form\ChoiceList\PhpcrOdmQueryBuilderLoader;
-use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 
 class DocumentType extends DoctrineType

--- a/Tests/Functional/Form/ChoiceList/PhpcrOdmQueryBuilderLoaderTest.php
+++ b/Tests/Functional/Form/ChoiceList/PhpcrOdmQueryBuilderLoaderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Doctrine\Bundle\PHPCRBundle\Tests\Functional\Form\ChoiceList;
+
+use Doctrine\Bundle\PHPCRBundle\Form\ChoiceList\PhpcrOdmQueryBuilderLoader;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+class PhpcrOdmQueryBuilderLoaderTest extends BaseTestCase
+{
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Doctrine\Bundle\PHPCRBundle\Tests\Resources\DataFixtures\PHPCR\LoadData',
+        ));
+
+        $this->dm = $this->getContainer()->get('doctrine_phpcr.odm.default_document_manager');
+    }
+
+    public function testGetByIds()
+    {
+        $qb = $this->dm->getRepository('Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument')->createQueryBuilder('e');
+        $loader = new PhpcrOdmQueryBuilderLoader($qb, $this->dm);
+        $documents = $loader->getEntitiesByIds('id', array('/test/doc'));
+        $this->assertCount(1, $documents);
+        $doc = reset($documents);
+        $this->assertInstanceOf('Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument', $doc);
+    }
+
+    public function testGetByIdsNotFound()
+    {
+        $qb = $this->dm->getRepository('Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument')->createQueryBuilder('e');
+        $loader = new PhpcrOdmQueryBuilderLoader($qb, $this->dm);
+        $documents = $loader->getEntitiesByIds('id', array('/foo/bar'));
+        $this->assertCount(0, $documents);
+    }
+
+    public function testGetByIdsFilter()
+    {
+        $qb = $this->dm->getRepository('Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument')->createQueryBuilder('e');
+        $qb->where()->eq()->field('e.text')->literal('thiswillnotmatch');
+        $loader = new PhpcrOdmQueryBuilderLoader($qb, $this->dm);
+        $documents = $loader->getEntitiesByIds('id', array('/test/doc'));
+        $this->assertCount(0, $documents);
+    }
+}

--- a/Tests/Functional/Form/PHPCRTypeGuesserTest.php
+++ b/Tests/Functional/Form/PHPCRTypeGuesserTest.php
@@ -3,17 +3,23 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Functional\Form;
 
 use Symfony\Component\Form\FormBuilderInterface;
-
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
 use Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument;
 use Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\ReferrerDocument;
+use Doctrine\ODM\PHPCR\DocumentManager;
 
 class PhpcrOdmTypeGuesserTest extends BaseTestCase
 {
     /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    /**
      * @var TestDocument
      */
     private $document;
+
     /**
      * @var ReferrerDocument
      */

--- a/Tests/Functional/Form/Type/DocumentTypeTest.php
+++ b/Tests/Functional/Form/Type/DocumentTypeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Doctrine\Bundle\PHPCRBundle\Tests\Functional\Form\Type;
+
+use Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\ReferrerDocument;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DocumentTypeTest extends BaseTestCase
+{
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    /**
+     * @var ReferrerDocument
+     */
+    private $referrer;
+
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Doctrine\Bundle\PHPCRBundle\Tests\Resources\DataFixtures\PHPCR\LoadData',
+        ));
+        $this->dm = $this->db('PHPCR')->getOm();
+        $document = $this->dm->find(null, '/test/doc');
+        $this->assertNotNull($document, 'fixture loading not working');
+        $this->referrer = $this->dm->find(null, '/test/ref');
+        $this->assertNotNull($this->referrer, 'fixture loading not working');
+    }
+
+    /**
+     * @return FormBuilderInterface
+     */
+    private function createFormBuilder($data, $options = array())
+    {
+        return $this->container->get('form.factory')->createBuilder('form', $data, $options);
+    }
+
+    /**
+     * Render a form and return the HTML
+     */
+    private function renderForm(FormBuilderInterface $formBuilder)
+    {
+        $formView = $formBuilder->getForm()->createView();
+        $templating = $this->getContainer()->get('templating');
+
+        return $templating->render('::form.html.twig', array('form' => $formView));
+    }
+
+    public function testUnfiltered()
+    {
+        $formBuilder = $this->createFormBuilder($this->referrer);
+
+        $formBuilder
+            ->add('single', 'phpcr_document', array(
+                'class' => 'Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument',
+            ))
+        ;
+
+        $html = $this->renderForm($formBuilder);
+        $this->assertContains('<select id="form_single" name="form[single]"', $html);
+        $this->assertContains('<option value="/test/doc"', $html);
+    }
+
+    public function testFiltered()
+    {
+        $qb = $this->dm
+            ->getRepository('Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument')
+            ->createQueryBuilder('e')
+        ;
+        $qb->where()->eq()->field('e.text')->literal('thiswillnotmatch');
+        $formBuilder = $this->createFormBuilder($this->referrer);
+
+        $formBuilder
+            ->add('single', 'phpcr_document', array(
+                'class' => 'Doctrine\Bundle\PHPCRBundle\Tests\Resources\Document\TestDocument',
+                'query_builder' => $qb,
+            ))
+        ;
+
+        $html = $this->renderForm($formBuilder);
+        $this->assertContains('<select id="form_single" name="form[single]"', $html);
+        $this->assertNotContains('<option', $html);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.3.27 || ~2.6.6 || ~2.7",
         "symfony/doctrine-bridge": "~2.3",
         "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "~1.2.0"


### PR DESCRIPTION
while working on https://github.com/symfony-cmf/BlogBundle/pull/59 and hunting down the last test failure, i found that the phpcr_document form type did not work but throw exceptions.

i also noticed that there is no test for this form type, neither functional nor unit.