### PR TITLE
StyleCI config bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 Tests/Resources/app/cache
 Tests/Resources/app/logs
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,9 @@
+<?php
+
+require_once __DIR__.'/vendor/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+
+return ConfigBridge::create()
+    ->setUsingCache(true)
+;

--- a/Command/DoctrineCommandHelper.php
+++ b/Command/DoctrineCommandHelper.php
@@ -55,7 +55,7 @@ abstract class DoctrineCommandHelper
      *
      * @param Application $application
      * @param string      $sessionName
-     * @param Boolean     $admin
+     * @param bool        $admin
      */
     public static function setApplicationPHPCRSession(Application $application, $sessionName, $admin = false)
     {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "symfony/form": "~2.3 || ~3.0",
         "doctrine/phpcr-odm": "~1.3@dev",
         "symfony-cmf/testing": "~1.2,>=1.2.7",
-        "matthiasnoback/symfony-dependency-injection-test": "~0.7"
+        "matthiasnoback/symfony-dependency-injection-test": "~0.7",
+        "sllh/php-cs-fixer-styleci-bridge": "~1.1@stable"
     },
     "suggest": {
         "phpcr/phpcr-shell": "If you want native access to PHPCR-Shell to manage the PHPCR repository",


### PR DESCRIPTION
The goal of this bridge is to provide an automatic configuration for php-cs-fixer based from StyleCI configuration.

I also added a Makefile to run cs and test with simple commands: `make cs` / `make test`.

I can remove it if you don't want to deal with Makefiles.