### PR TITLE
skip query when there is no valid id

### DIFF
--- a/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
+++ b/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
@@ -80,6 +80,14 @@ class PhpcrOdmQueryBuilderLoader implements EntityLoaderInterface
      */
     public function getEntitiesByIds($identifier, array $values)
     {
+        $values = array_values(array_filter($values, function ($v) {
+            return !empty($v);
+        }));
+
+        if (0 == count($values)) {
+            return array();
+        }
+
         /* performance: if we could figure out whether the query builder is "
          * empty" (that is only checking for the class) we could optimize this
          * to a $this->dm->findMany(null, $values)


### PR DESCRIPTION
see my comment on the source code of the commit that introduced that f393c067ca11f24175d3a5f450329fb2d3129fca