### PR TITLE
do not treat deprecation warnings as errors in maintenance branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - COMPOSER_ROOT_VERSION=dev-master composer require symfony/symfony:${SYMFONY_VERSION}
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
-script: phpunit --coverage-text
+script: SYMFONY_DEPRECATIONS_HELPER=weak phpunit --coverage-text
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_install:
   - composer self-update || true
   - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-  - COMPOSER_ROOT_VERSION=dev-master composer require symfony/symfony:${SYMFONY_VERSION}
+  - COMPOSER_ROOT_VERSION=dev-master composer require symfony/symfony:${SYMFONY_VERSION} symfony/framework-bundle:${SYMFONY_VERSION}
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script: SYMFONY_DEPRECATIONS_HELPER=weak phpunit --coverage-text


### PR DESCRIPTION
hopefully this change will get us rid of the failures because of deprecated constructs.