### PR TITLE
Ensured fallback is only set to a valid value

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -81,7 +81,16 @@ class LocaleListener implements EventSubscriberInterface
     {
         $this->chooser = $chooser;
         $this->allowedLocales = $allowedLocales;
-        $this->fallback = $fallback;
+        switch ($fallback) {
+            case self::FALLBACK_MERGE:
+            case self::FALLBACK_REPLACE:
+            case self::FALLBACK_HARDCODED:
+                $this->fallback = $fallback;
+                break;
+            default:
+                $this->fallback = self::FALLBACK_HARDCODED;
+                break;
+        }
     }
 
     /**

--- a/Tests/Unit/EventListener/LocaleListenerTest.php
+++ b/Tests/Unit/EventListener/LocaleListenerTest.php
@@ -61,6 +61,32 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $localeListener->onKernelRequest($this->responseEvent);
     }
 
+    public function testOnKernelRequestWithDefaultFallback()
+    {
+        $this->setUpTestOnKernelRequest();
+
+        $localeListener = new LocaleListener(
+            $this->chooser,
+            $this->allowedLocales,
+            null
+        );
+
+        $this->responseEvent->expects($this->exactly(4))
+            ->method('getRequest')
+            ->will($this->returnValue($this->request));
+
+        $this->request->expects($this->exactly(2))
+            ->method('getLocale')
+            ->will($this->onConsecutiveCalls('it', 'fr'));
+
+        $this->chooser->expects($this->once())
+            ->method('setLocale')
+            ->with($this->equalTo('fr'));
+
+        $localeListener->onKernelRequest($this->responseEvent);
+        $localeListener->onKernelRequest($this->responseEvent);
+    }
+
     public function testOnKernelRequestWithFallbackReplace()
     {
         $this->setUpTestOnKernelRequest();


### PR DESCRIPTION
Not sure if this is the best way to test this as I just copied and pasted the test for the explicit hardcoded fallback and changed that value to null. Would it be better to check the class property has been set correctly (via reflection)?

Also, the implementation applies a strict check to ensure the fallback value is definitely set to one of the allowed values. Is that overkill? We could just check for a null and set the correct value there.

Fixes #221