### PR TITLE
Fix explicit null passed as fallback 1.2

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -82,7 +82,16 @@ class LocaleListener implements EventSubscriberInterface
     {
         $this->chooser = $chooser;
         $this->allowedLocales = $allowedLocales;
-        $this->fallback = $fallback;
+        switch ($fallback) {
+            case self::FALLBACK_MERGE:
+            case self::FALLBACK_REPLACE:
+            case self::FALLBACK_HARDCODED:
+                $this->fallback = $fallback;
+                break;
+            default:
+                $this->fallback = self::FALLBACK_HARDCODED;
+                break;
+        }
     }
 
     /**

--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -78,7 +78,7 @@ class LocaleListener implements EventSubscriberInterface
      * @param string        $fallback       One of the FALLBACK_* constants.
      *
      */
-    public function __construct(LocaleChooser $chooser, array $allowedLocales, $fallback = self::FALLBACK_HARDCODED)
+    public function __construct(LocaleChooser $chooser, array $allowedLocales, $fallback = self::FALLBACK_MERGE)
     {
         $this->chooser = $chooser;
         $this->allowedLocales = $allowedLocales;
@@ -89,7 +89,7 @@ class LocaleListener implements EventSubscriberInterface
                 $this->fallback = $fallback;
                 break;
             default:
-                $this->fallback = self::FALLBACK_HARDCODED;
+                $this->fallback = self::FALLBACK_MERGE;
                 break;
         }
     }

--- a/Tests/Unit/EventListener/LocaleListenerTest.php
+++ b/Tests/Unit/EventListener/LocaleListenerTest.php
@@ -60,6 +60,32 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $localeListener->onKernelRequest($this->responseEvent);
     }
 
+    public function testOnKernelRequestWithDefaultFallback()
+    {
+        $this->setUpTestOnKernelRequest();
+
+        $localeListener = new LocaleListener(
+            $this->chooser,
+            $this->allowedLocales,
+            null
+        );
+
+        $this->responseEvent->expects($this->exactly(4))
+            ->method('getRequest')
+            ->will($this->returnValue($this->request));
+
+        $this->request->expects($this->exactly(2))
+            ->method('getLocale')
+            ->will($this->onConsecutiveCalls('it', 'fr'));
+
+        $this->chooser->expects($this->once())
+            ->method('setLocale')
+            ->with($this->equalTo('fr'));
+
+        $localeListener->onKernelRequest($this->responseEvent);
+        $localeListener->onKernelRequest($this->responseEvent);
+    }
+
     public function testOnKernelRequestWithFallbackReplace()
     {
         $this->setUpTestOnKernelRequest();

--- a/Tests/Unit/EventListener/LocaleListenerTest.php
+++ b/Tests/Unit/EventListener/LocaleListenerTest.php
@@ -70,19 +70,27 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $this->responseEvent->expects($this->exactly(4))
+        $this->responseEvent->expects($this->exactly(2))
             ->method('getRequest')
             ->will($this->returnValue($this->request));
 
-        $this->request->expects($this->exactly(2))
+        $this->request->expects($this->once())
             ->method('getLocale')
-            ->will($this->onConsecutiveCalls('it', 'fr'));
+            ->will($this->onConsecutiveCalls('en'));
 
         $this->chooser->expects($this->once())
             ->method('setLocale')
-            ->with($this->equalTo('fr'));
+            ->with($this->equalTo('en'));
 
-        $localeListener->onKernelRequest($this->responseEvent);
+        $this->request->expects($this->once())
+            ->method('getLanguages')
+            ->will($this->returnValue(array('it', 'fr_FR', 'fr_CA', 'en_GB')));
+
+        $this->chooser->expects($this->once())
+            ->method('setFallbackLocales')
+            ->with('en', array('fr', 'en'), false);
+
+
         $localeListener->onKernelRequest($this->responseEvent);
     }
 


### PR DESCRIPTION
Follow on from https://github.com/doctrine/DoctrinePHPCRBundle/pull/222

I have changed the default strategy to be MERGE as requested by @dbu 

Also this is a branch off 1.2 rather than master.