### PR TITLE
Verification of unique node type in support of real outer joins

### DIFF
--- a/CacheWarmer/UniqueNodeTypeCacheWarmer.php
+++ b/CacheWarmer/UniqueNodeTypeCacheWarmer.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\PHPCRBundle\CacheWarmer;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ODM\PHPCR\Tools\Helper\UniqueNodeTypeHelper;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Hook the verification of uniquely mapped node types into the cache
+ * warming process, thereby providing a useful indication to the
+ * developer that something is wrong.
+ */
+class UniqueNodeTypeCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * @var ManagerRegistry
+     */
+    private $registry;
+
+    /**
+     * Constructor.
+     *
+     * @param ManagerRegistry $registry A ManagerRegistry instance
+     */
+    public function __construct(ManagerRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * This cache warmer is optional as it is just for error
+     * checking and reporting back to the user.
+     *
+     * @return true
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        foreach ($this->registry->getManagers() as $documentManager) {
+            UniqueNodeTypeHelper::checkNodeTypeMappings($documentManager);
+        }
+    }
+}

--- a/DoctrinePHPCRBundle.php
+++ b/DoctrinePHPCRBundle.php
@@ -31,8 +31,9 @@ use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\MigratorPass;
 use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\InitializerPass;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\InitDoctrineDbalCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\JackrabbitCommand;
-use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\InfoDoctrineCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\DocumentMigrateClassCommand;
+use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\InfoDoctrineCommand;
+use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\VerifyUniqueNodeTypesMappingCommand;
 
 class DoctrinePHPCRBundle extends Bundle
 {
@@ -62,8 +63,9 @@ class DoctrinePHPCRBundle extends Bundle
         parent::registerCommands($application);
 
         if (class_exists('Doctrine\ODM\PHPCR\Version')) {
-            $application->add(new InfoDoctrineCommand());
             $application->add(new DocumentMigrateClassCommand());
+            $application->add(new InfoDoctrineCommand());
+            $application->add(new VerifyUniqueNodeTypesMappingCommand());
         }
 
         if (class_exists('\Jackalope\Tools\Console\Command\JackrabbitCommand')) {

--- a/OptionalCommand/ODM/VerifyUniqueNodeTypesMappingCommand.php
+++ b/OptionalCommand/ODM/VerifyUniqueNodeTypesMappingCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM;
+
+use Doctrine\Bundle\PHPCRBundle\Command\DoctrineCommandHelper;
+use Doctrine\ODM\PHPCR\Tools\Console\Command\VerifyUniqueNodeTypesMappingCommand as BaseVerifyUniqueNodeTypesMappingCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Wrapper to use this command in the Symfony console with multiple sessions.
+ */
+class VerifyUniqueNodeTypesMappingCommand extends BaseVerifyUniqueNodeTypesMappingCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('doctrine:phpcr:mapping:verify_unique_node_types')
+            ->setDescription('Verify that documents with unique node types are correctly mapped')
+            ->addOption('session', null, InputOption::VALUE_OPTIONAL, 'The session to use for this command')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command checks all mapped PHPCR-ODM documents
+and verifies that any marked as having unique node types are, in fact, unique.
+EOT
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        DoctrineCommandHelper::setApplicationDocumentManager(
+            $this->getApplication(),
+            $input->getOption('session')
+        );
+
+        parent::execute($input, $output);
+    }
+}

--- a/OptionalCommand/ODM/VerifyUniqueNodeTypesMappingCommand.php
+++ b/OptionalCommand/ODM/VerifyUniqueNodeTypesMappingCommand.php
@@ -39,12 +39,12 @@ class VerifyUniqueNodeTypesMappingCommand extends BaseVerifyUniqueNodeTypesMappi
         parent::configure();
 
         $this
-            ->setName('doctrine:phpcr:mapping:verify_unique_node_types')
-            ->setDescription('Verify that documents with unique node types are correctly mapped')
+            ->setName('doctrine:phpcr:mapping:verify-unique-node-types')
+            ->setDescription('Verify that documents claiming to have unique node types are truly unique')
             ->addOption('session', null, InputOption::VALUE_OPTIONAL, 'The session to use for this command')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command checks all mapped PHPCR-ODM documents
-and verifies that any marked as having unique node types are, in fact, unique.
+and verifies that any claiming to use unique node types are truly unique.
 EOT
         );
     }

--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -37,6 +37,7 @@
         <parameter key="doctrine_phpcr.odm.metadata.yml.class">Doctrine\Bundle\PHPCRBundle\Mapping\Driver\YamlDriver</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.php.class">Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver</parameter>
         <parameter key="doctrine_phpcr.odm.proxy_cache_warmer.class">Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer</parameter>
+        <parameter key="doctrine_phpcr.odm.unique_node_type_cache_warmer.class">Doctrine\Bundle\PHPCRBundle\CacheWarmer\UniqueNodeTypeCacheWarmer</parameter>
 
         <!-- validator -->
         <parameter key="doctrine_phpcr.odm.validator.valid_phpcr_odm.class">Doctrine\Bundle\PHPCRBundle\Validator\Constraints\ValidPhpcrOdmValidator</parameter>
@@ -45,6 +46,12 @@
     <services>
 
         <service id="doctrine_phpcr.odm.proxy_cache_warmer" class="%doctrine_phpcr.odm.proxy_cache_warmer.class%"
+                 public="false">
+            <tag name="kernel.cache_warmer"/>
+            <argument type="service" id="doctrine_phpcr"/>
+        </service>
+
+        <service id="doctrine_phpcr.odm.unique_node_type_cache_warmer" class="%doctrine_phpcr.odm.unique_node_type_cache_warmer.class%"
                  public="false">
             <tag name="kernel.cache_warmer"/>
             <argument type="service" id="doctrine_phpcr"/>


### PR DESCRIPTION
This is a companion to doctrine/phpcr-odm#667 which introduces the designation of documents using unique node types at the mapping level in order to support real outer joins in Jackrabbit. This PR introduces a shell command and hooks the verification into the cache warming process.