### PR TITLE
revert locking tests to dev version of symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 env:
@@ -15,14 +16,11 @@ matrix:
   include:
     - php: 5.3
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
+    - php: 7.0
       env: SYMFONY_VERSION=2.3.* SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 5.6
+    - php: 7.0
       env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-  allow_failures:
-    - php: 5.6
+    - php: 7.0
       env: SYMFONY_VERSION=3.0.*
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ env:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 matrix:
   include:
     - php: 5.3
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.0
-      env: SYMFONY_VERSION=2.3.*
     - php: 7.0
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
@@ -26,8 +28,8 @@ matrix:
 
 before_install:
   - composer self-update || true
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-  - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;
   - COMPOSER_ROOT_VERSION=dev-master composer update $COMPOSER_FLAGS --prefer-source --no-interaction
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
@@ -36,3 +38,4 @@ script: ./vendor/bin/phpunit --coverage-text
 notifications:
   irc: "irc.freenode.org#symfony-cmf"
   email: "symfony-cmf-devs@googlegroups.com"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - hhvm
 
 env:
-  - SYMFONY_VERSION="2.7.*,>2.7.6"
+  - SYMFONY_VERSION="~2.3||~3.0"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
+  fast_finish: true
 
 before_install:
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 
 env:
-  - SYMFONY_VERSION="~2.3||~3.0"
+  - SYMFONY_VERSION="2.8.*"
 
 sudo: false
 
@@ -17,9 +17,9 @@ matrix:
     - php: 5.3
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.0
-      env: SYMFONY_VERSION=2.3.* SYMFONY_DEPRECATIONS_HELPER=weak
+      env: SYMFONY_VERSION=2.3.*
     - php: 7.0
-      env: SYMFONY_VERSION=2.8.*
+      env: SYMFONY_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
 

--- a/Tests/Resources/Document/TestDocument.php
+++ b/Tests/Resources/Document/TestDocument.php
@@ -54,62 +54,62 @@ class TestDocument
     protected $mixedReferrers;
 
     /**
-     * @PHPCR\Boolean()
+     * @PHPCR\Field(type="boolean")
      */
     public $bool;
 
     /**
-     * @PHPCR\Date()
+     * @PHPCR\Field(type="date")
      */
     public $date;
 
     /**
-     * @PHPCR\String()
+     * @PHPCR\Field(type="string")
      */
     public $text;
 
     /**
-     * @PHPCR\Double()
+     * @PHPCR\Field(type="double")
      */
     public $number;
 
     /**
-     * @PHPCR\Long()
+     * @PHPCR\Field(type="long")
      */
     public $long;
 
     /**
-     * @PHPCR\Int()
+     * @PHPCR\Field(type="int")
      */
     public $integer;
 
     /**
-     * @PHPCR\Boolean(multivalue=true, nullable=true)
+     * @PHPCR\Field(type="boolean", multivalue=true, nullable=true)
      */
     public $mbool;
 
     /**
-     * @PHPCR\Date(multivalue=true, nullable=true)
+     * @PHPCR\Field(type="date", multivalue=true, nullable=true)
      */
     public $mdate;
 
     /**
-     * @PHPCR\String(multivalue=true, nullable=true)
+     * @PHPCR\Field(type="string", multivalue=true, nullable=true)
      */
     public $mtext;
 
     /**
-     * @PHPCR\Double(multivalue=true, nullable=true)
+     * @PHPCR\Field(type="double", multivalue=true, nullable=true)
      */
     public $mnumber;
 
     /**
-     * @PHPCR\Long(multivalue=true, nullable=true)
+     * @PHPCR\Field(type="long", multivalue=true, nullable=true)
      */
     public $mlong;
 
     /**
-     * @PHPCR\Int(multivalue=true, nullable=true)
+     * @PHPCR\Field(type="int", multivalue=true, nullable=true)
      */
     public $minteger;
 

--- a/Tests/Unit/Form/Type/PathTypeTest.php
+++ b/Tests/Unit/Form/Type/PathTypeTest.php
@@ -6,7 +6,6 @@ use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
 use Doctrine\Bundle\PHPCRBundle\Form\Type\PathType;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PathTypeTest extends \PHPUnit_Framework_Testcase
 {
@@ -71,13 +70,5 @@ class PathTypeTest extends \PHPUnit_Framework_Testcase
             }));
 
         $this->type->buildForm($this->builder, array('manager_name' => null));
-    }
-
-    public function testSetDefaultOptions()
-    {
-        $this->optionsResolver->expects($this->once())
-            ->method('setDefaults')
-            ->with(array('manager_name' => null));
-        $this->type->setDefaultOptions($this->optionsResolver);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,20 +19,19 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.3.9|~7.0",
-        "symfony/symfony": "~2.3",
-        "symfony/framework-bundle": "~2.3.27 || ^2.6.6 || ~3.0",
-        "symfony/doctrine-bridge": "~2.3 || ~3.0",
+        "symfony/framework-bundle": "^2.3.27|^2.6.6|~3.0",
+        "symfony/doctrine-bridge": "~2.3|~3.0",
         "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "^1.2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
-        "phpunit/php-code-coverage": "@stable",
-        "symfony/form": "~2.3 || ~3.0",
-        "doctrine/phpcr-odm": "~1.3,>1.3.0-rc3",
-        "symfony-cmf/testing": "dev-remove_csrf_protection as 1.3.0",
+        "phpunit/php-code-coverage": "~2.2",
+        "symfony/form": "~2.3|~3.0",
+        "doctrine/phpcr-odm": "^1.3.0-rc4",
+        "symfony-cmf/testing": "^1.3.0",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7",
-        "sllh/php-cs-fixer-styleci-bridge": "~1.1@stable"
+        "sllh/php-cs-fixer-styleci-bridge": "~1.1"
     },
     "suggest": {
         "phpcr/phpcr-shell": "If you want native access to PHPCR-Shell to manage the PHPCR repository",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.3.9",
+        "php": "^5.3.9|~7.0",
+        "symfony/symfony": "~2.3",
         "symfony/framework-bundle": "~2.3.27 || ^2.6.6 || ~3.0",
         "symfony/doctrine-bridge": "~2.3 || ~3.0",
         "phpcr/phpcr-implementation": "2.1.*",
@@ -29,7 +30,7 @@
         "phpunit/php-code-coverage": "@stable",
         "symfony/form": "~2.3 || ~3.0",
         "doctrine/phpcr-odm": "~1.3,>1.3.0-rc3",
-        "symfony-cmf/testing": "^1.3.0",
+        "symfony-cmf/testing": "dev-remove_csrf_protection as 1.3.0",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7",
         "sllh/php-cs-fixer-styleci-bridge": "~1.1@stable"
     },


### PR DESCRIPTION
revert hack of #231 once https://github.com/symfony/symfony/commit/1bdd127938058a1f34fd0bc883ebb9e4d6ccf67d is included in a 2.7 release.