### PR TITLE
do not hardcode a symfony version for the general builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ php:
   - 7.0
   - hhvm
 
-env:
-  - SYMFONY_VERSION="2.8.*"
-
 sudo: false
 
 cache:
@@ -23,7 +20,7 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=2.8.*
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
why do we get low symfony versions if we do not hardcode a specific version?