### PR TITLE
update version constraint for FrameworkBundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ php:
   - 7.0
   - hhvm
 
-env:
-  - SYMFONY_VERSION="2.8.*"
-
 sudo: false
 
 cache:
@@ -23,7 +20,7 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=2.8.*
   fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.3.9|~7.0",
-        "symfony/framework-bundle": "^2.3.27|^2.6.6|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/doctrine-bridge": "~2.3|~3.0",
         "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "^1.2.7"
@@ -43,7 +43,8 @@
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*"
     },
     "conflict": {
-        "phpcr/phpcr-shell": "<1.0.0-beta1"
+        "phpcr/phpcr-shell": "<1.0.0-beta1",
+        "symfony/framework-bundle": "<2.3.27|>=2.6.0,<2.6.6"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\PHPCRBundle\\": "" }


### PR DESCRIPTION
Using a conflict rule instead of listing all allowed versions with require seems to let Composer properly resolve the desired Symfony versions without having to enforce them.