### PR TITLE
[Bugfix] Do not call non-static method as static method

### DIFF
--- a/CacheWarmer/UniqueNodeTypeCacheWarmer.php
+++ b/CacheWarmer/UniqueNodeTypeCacheWarmer.php
@@ -63,7 +63,7 @@ class UniqueNodeTypeCacheWarmer implements CacheWarmerInterface
     public function warmUp($cacheDir)
     {
         $helper = new UniqueNodeTypeHelper();
-        
+
         foreach ($this->registry->getManagers() as $documentManager) {
             $helper->checkNodeTypeMappings($documentManager);
         }

--- a/CacheWarmer/UniqueNodeTypeCacheWarmer.php
+++ b/CacheWarmer/UniqueNodeTypeCacheWarmer.php
@@ -62,8 +62,10 @@ class UniqueNodeTypeCacheWarmer implements CacheWarmerInterface
      */
     public function warmUp($cacheDir)
     {
+        $helper = new UniqueNodeTypeHelper();
+        
         foreach ($this->registry->getManagers() as $documentManager) {
-            UniqueNodeTypeHelper::checkNodeTypeMappings($documentManager);
+            $helper->checkNodeTypeMappings($documentManager);
         }
     }
 }


### PR DESCRIPTION
Static was removed from this method in 1.3: https://github.com/doctrine/phpcr-odm/pull/667 (not sure why though) This now errors when warming up the cache.