### PR TITLE
default to not check login on backend even in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 Changelog
 =========
 
+1.3.1
+-----
+
+* Reverted jackalope.check_login_on_server depending on kernel.debug because
+  it caused too many chicken and egg problems. That value now defaults to false.
+
 1.2.1
 -----
 
 * Added support for priorities. This fixes a regression whereby the new CMF initializer services would
-  be executed in an arbitry order, causing unresolvable conflicts.
+  be executed in an arbitrary order, causing unresolvable conflicts.
 
 1.2.0-RC1
 ---------

--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -212,7 +212,7 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         $backendParameters += $session['backend']['parameters'];
         // only set this default here when we know we are jackalope
         if (!isset($backendParameters['jackalope.check_login_on_server'])) {
-            $backendParameters['jackalope.check_login_on_server'] = $container->getParameter('kernel.debug');
+            $backendParameters['jackalope.check_login_on_server'] = false;
         }
 
         if ('doctrinedbal' === $type && $backendParameters['jackalope.check_login_on_server']) {


### PR DESCRIPTION
fix #244 
doc: need to revert https://github.com/symfony-cmf/symfony-cmf-docs/pull/723