### PR TITLE
 default to not check login on backend even in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 Changelog
 =========
 
+1.3.1
+-----
+
+* Reverted jackalope.check_login_on_server depending on kernel.debug because
+  it caused too many chicken and egg problems. That value now defaults to false.
+
 1.2.1
 -----
 
 * Added support for priorities. This fixes a regression whereby the new CMF initializer services would
-  be executed in an arbitry order, causing unresolvable conflicts.
+  be executed in an arbitrary order, causing unresolvable conflicts.
 
 1.2.0-RC1
 ---------

--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -212,7 +212,7 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         $backendParameters += $session['backend']['parameters'];
         // only set this default here when we know we are jackalope
         if (!isset($backendParameters['jackalope.check_login_on_server'])) {
-            $backendParameters['jackalope.check_login_on_server'] = $container->getParameter('kernel.debug');
+            $backendParameters['jackalope.check_login_on_server'] = false;
         }
 
         if ('doctrinedbal' === $type && $backendParameters['jackalope.check_login_on_server']) {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.3.9|~7.0",
-        "symfony/framework-bundle": "~2.3.27|^2.6.6|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/doctrine-bridge": "~2.3|~3.0",
         "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "^1.2.7"
@@ -43,7 +43,8 @@
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*"
     },
     "conflict": {
-        "phpcr/phpcr-shell": "<1.0.0-beta1"
+        "phpcr/phpcr-shell": "<1.0.0-beta1",
+        "symfony/framework-bundle": "<2.3.27|>=2.4.0,<2.6.6"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\PHPCRBundle\\": "" }


### PR DESCRIPTION
This applies @dbu's changes from #249 and on top of that readds conflict rules which have been removed in #246. This way, we can work around issues like composer/composer#3754 and composer/composer#4735.