### PR TITLE
Repository init - pass "session" parameter to initializers implementing the new SessionAwareInitializerInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3.5
+-----
+
+* Added support for `session` parameter in repository initializers by implementing SessionAwareInitializerInterface. GenericInitializer now implements this new interface.
+
 1.3.4
 -----
 

--- a/Command/RepositoryInitCommand.php
+++ b/Command/RepositoryInitCommand.php
@@ -78,6 +78,6 @@ EOT
             $output->writeln($message);
         });
 
-        $initializerManager->initialize();
+        $initializerManager->initialize($input->getOption('session'));
     }
 }

--- a/Initializer/GenericInitializer.php
+++ b/Initializer/GenericInitializer.php
@@ -67,7 +67,7 @@ class GenericInitializer implements InitializerInterface, SessionAwareInitialize
     /**
      * @param array       $basePaths a list of base paths to create if not existing
      * @param string|null $cnd       node type and namespace definitions in cnd
-     *                               format, pass null to not create any node types.
+     *                               format, pass null to not create any node types
      */
     public function __construct($name, array $basePaths, $cnd = null)
     {

--- a/Initializer/GenericInitializer.php
+++ b/Initializer/GenericInitializer.php
@@ -36,7 +36,7 @@ use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-class GenericInitializer implements InitializerInterface
+class GenericInitializer implements InitializerInterface, SessionAwareInitializerInterface
 {
     /**
      * Name for this initializer.
@@ -57,6 +57,12 @@ class GenericInitializer implements InitializerInterface
      * @var array
      */
     protected $basePaths;
+    /**
+     * Name of the session in which this initializer should run.
+     *
+     * @var string
+     */
+    protected $sessionName;
 
     /**
      * @param array       $basePaths a list of base paths to create if not existing
@@ -75,7 +81,7 @@ class GenericInitializer implements InitializerInterface
      */
     public function init(ManagerRegistry $registry)
     {
-        $session = $registry->getConnection();
+        $session = $registry->getConnection($this->sessionName);
 
         if ($this->cnd) {
             $this->registerCnd($session, $this->cnd);
@@ -88,6 +94,11 @@ class GenericInitializer implements InitializerInterface
     public function getName()
     {
         return $this->name;
+    }
+
+    public function setSessionName($sessionName)
+    {
+        $this->sessionName = $sessionName;
     }
 
     protected function registerCnd(SessionInterface $session, $cnd)

--- a/Initializer/InitializerManager.php
+++ b/Initializer/InitializerManager.php
@@ -91,8 +91,8 @@ class InitializerManager
             if ($sessionName) {
                 if (in_array('Doctrine\Bundle\PHPCRBundle\Initializer\SessionAwareInitializerInterface', class_implements($initializer))) {
                     $initializer->setSessionName($sessionName);
-                } else {
-                    $loggingClosure(sprintf('<comment>Initializer "%s" does not implement SessionAwareInitializerInterface, executing in default session.</comment>', $initializer->getName()));
+                } else if ($loggingClosure) {
+                    $loggingClosure(sprintf('<comment>Initializer "%s" does not implement SessionAwareInitializerInterface, "session" parameter will be ommitted.</comment>', $initializer->getName()));
                 }
             }
 

--- a/Initializer/InitializerManager.php
+++ b/Initializer/InitializerManager.php
@@ -91,7 +91,7 @@ class InitializerManager
             if ($sessionName) {
                 if (in_array('Doctrine\Bundle\PHPCRBundle\Initializer\SessionAwareInitializerInterface', class_implements($initializer))) {
                     $initializer->setSessionName($sessionName);
-                } else if ($loggingClosure) {
+                } elseif ($loggingClosure) {
                     $loggingClosure(sprintf('<comment>Initializer "%s" does not implement SessionAwareInitializerInterface, "session" parameter will be ommitted.</comment>', $initializer->getName()));
                 }
             }

--- a/Initializer/InitializerManager.php
+++ b/Initializer/InitializerManager.php
@@ -78,13 +78,22 @@ class InitializerManager
     /**
      * Iterate over the registered initializers and execute each of them.
      */
-    public function initialize()
+    public function initialize($sessionName = null)
     {
         $loggingClosure = $this->loggingClosure;
 
         foreach ($this->getInitializers() as $initializer) {
             if ($loggingClosure) {
                 $loggingClosure(sprintf('<info>Executing initializer:</info> %s', $initializer->getName()));
+            }
+
+            // handle specified session if present
+            if ($sessionName) {
+                if (in_array('Doctrine\Bundle\PHPCRBundle\Initializer\SessionAwareInitializerInterface', class_implements($initializer))) {
+                    $initializer->setSessionName($sessionName);
+                } else {
+                    $loggingClosure(sprintf('<comment>Initializer "%s" does not implement SessionAwareInitializerInterface, executing in default session.</comment>', $initializer->getName()));
+                }
             }
 
             $initializer->init($this->registry);

--- a/Initializer/SessionAwareInitializerInterface.php
+++ b/Initializer/SessionAwareInitializerInterface.php
@@ -32,7 +32,7 @@ interface SessionAwareInitializerInterface
     /**
      * Set session name for this initilizer.
      *
-     * @param string    $sessionName
+     * @param string $sessionName
      */
     public function setSessionName($sessionName);
 }

--- a/Initializer/SessionAwareInitializerInterface.php
+++ b/Initializer/SessionAwareInitializerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\PHPCRBundle\Initializer;
+
+/**
+ * Interface for session aware intiializers.
+ * Handles running initializer in specified session
+ * instead of the default one.
+ *
+ * @author michalpolko <michalpolko@o2.pl>
+ */
+interface SessionAwareInitializerInterface
+{
+    /**
+     * Set session name for this initilizer.
+     *
+     * @param string    $sessionName
+     */
+    public function setSessionName($sessionName);
+}


### PR DESCRIPTION
Fix for issue #262, as proposed by @dbu.
Also added some logging in a case where session parameter is specified but the initializer doesn't implement the SessionAware interface.