### PR TITLE
added connection to service configuration of RepositorySchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 (unreleased)
 ------------
 
+* Added connection parameter to RepositorySchema, so that the DBAL configuration applies. This will affect
+  you if you configured connection options for DBAL, but will not affect already created tables.
 * Added support for `session` parameter in repository initializers with the new `SessionAwareInitializerInterface`.
   GenericInitializer now implements this new interface.
 

--- a/Resources/config/jackalope.xml
+++ b/Resources/config/jackalope.xml
@@ -51,7 +51,10 @@
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema"
                  class="%doctrine_phpcr.jackalope_doctrine_dbal.repository_schema.class%"
                  public="false"
-        />
+        >
+            <argument type="collection"/>
+            <argument type="service" id="doctrine.dbal.default_connection"/>
+        </service>
 
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema_listener"
                  class="%doctrine_phpcr.jackalope_doctrine_dbal.schema_listener.class%">


### PR DESCRIPTION
The following issue in Sulu was reported: https://github.com/sulu/sulu/issues/3106

Long story short: Currently utf8 emojis like "🎄" are not working with jackalope-doctrine-dbal, because it uses the limited `utf8` charset instead of `utf8mb4`. I thought I can simply change the charset in doctrine dbal, but jackalope seemed to ignore it.

I found out that the service configuration didn't pass the `Connection` class, so it was using some default values instead of what has been defined in the DoctrineBundle. So the tables defined in the [RepositorySchema](https://github.com/jackalope/jackalope-doctrine-dbal/blob/75bfb54453f224a9e848cee70cc85bf8d48c4556/src/Jackalope/Transport/DoctrineDBAL/RepositorySchema.php#L37) did not use the `default_table_options` defined in the application configuration.

After changing this there was another error when creating the table, for which I will create another PR in jackalope-doctrine-dbal.

I hope simply injecting the default connection is good enough, although I can imagine that there are some usecases where this should be configurable. Maybe we should move that logic to the extension somehow?