### PR TITLE
Inject configured dbal connection

### DIFF
--- a/Resources/config/jackalope.xml
+++ b/Resources/config/jackalope.xml
@@ -53,7 +53,7 @@
                  public="false"
         >
             <argument type="collection"/>
-            <argument type="service" id="doctrine.dbal.default_connection"/>
+            <argument type="service" id="jackalope_doctrine_dbal.default_connection"/>
         </service>
 
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema_listener"


### PR DESCRIPTION
Instead of injecting the default dbal connection, inject whichever dbal connection has been configured. E.g.:
```yaml
doctrine_phpcr:
    # configure the PHPCR session
    session:
        backend:
            connection: a_connection_name
```
Also see https://github.com/doctrine/DoctrinePHPCRBundle/issues/271