### PR TITLE
Correction to service argument allowing for multiple named dbal connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 sudo: false
 
@@ -21,6 +20,8 @@ matrix:
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_VERSION=2.8.*
+    - php: hhvm
+      dist: trusty
   fast_finish: true
 
 before_install:

--- a/Resources/config/jackalope.xml
+++ b/Resources/config/jackalope.xml
@@ -53,7 +53,7 @@
                  public="false"
         >
             <argument type="collection"/>
-            <argument type="service" id="jackalope_doctrine_dbal.default_connection"/>
+            <argument type="service" id="doctrine_phpcr.jackalope_doctrine_dbal. default_connection"/>
         </service>
 
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema_listener"

--- a/Resources/config/jackalope.xml
+++ b/Resources/config/jackalope.xml
@@ -53,7 +53,7 @@
                  public="false"
         >
             <argument type="collection"/>
-            <argument type="service" id="doctrine_phpcr.jackalope_doctrine_dbal. default_connection"/>
+            <argument type="service" id="doctrine_phpcr.jackalope_doctrine_dbal.default_connection"/>
         </service>
 
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema_listener"

--- a/Resources/config/jackalope.xml
+++ b/Resources/config/jackalope.xml
@@ -53,7 +53,7 @@
                  public="false"
         >
             <argument type="collection"/>
-            <argument type="service" id="doctrine.dbal.default_connection"/>
+            <argument type="service" id="jackalope_doctrine_dbal.default_connection"/>
         </service>
 
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema_listener"

--- a/Tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToPathTransformer;
-use Jackalope\Node;
 
 class PHPCRNodeToPathTransformerTest extends \PHPUnit_Framework_Testcase
 {

--- a/Tests/Unit/Form/DataTransformer/PHPCRNodeToUuidTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/PHPCRNodeToUuidTransformerTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToUuidTransformer;
-use Jackalope\Node;
 
 class PHPCRNodeToUuidTransformerTest extends \PHPUnit_Framework_Testcase
 {


### PR DESCRIPTION
See latest comments on https://github.com/doctrine/DoctrinePHPCRBundle/issues/271

Previous PR used ID `jackalope_doctrine_dbal.default_connection` instead of `doctrine_phpcr.jackalope_doctrine_dbal.default_connection`

Allows for multiple dbal connections and defining the connection to use in doctrine_phpcr:
```yaml
doctrine_phpcr:
    session:
        backend:
            connection: a_connection_name
```

`doctrine.dbal.default_connection` does not exist when multiple connections are defined like this for example:
```yaml
doctrine:
    dbal:
        default_connection: main
        connections:
            main:
                driver: pdo_mysql
                host: '%database_host%'
                port: '%database_port%'
                dbname: '%database_name%'
                user: '%database_user%'
                password: '%database_password%'
                charset: utf8mb4
                default_table_options:
                    charset: utf8mb4
                    collate: utf8mb4_unicode_ci
            secondary:
                driver: pdo_sqlite
                charset: utf8mb4
                default_table_options:
                    charset: utf8mb4
                    collate: utf8mb4_unicode_ci
                path: '%database_path%'
```