### PR TITLE
use ChildDefinition over DefinitionDecorator when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 sudo: false
 
@@ -21,6 +20,8 @@ matrix:
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_VERSION=2.8.*
+    - php: hhvm
+      dist: trusty
   fast_finish: true
 
 before_install:

--- a/Tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToPathTransformer;
-use Jackalope\Node;
 
 class PHPCRNodeToPathTransformerTest extends \PHPUnit_Framework_Testcase
 {

--- a/Tests/Unit/Form/DataTransformer/PHPCRNodeToUuidTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/PHPCRNodeToUuidTransformerTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToUuidTransformer;
-use Jackalope\Node;
 
 class PHPCRNodeToUuidTransformerTest extends \PHPUnit_Framework_Testcase
 {


### PR DESCRIPTION
to avoid deprecation warnings with symfony 3.3+ and be future proof for symfony 4.