### PR TITLE
Use correct dbal connection if multiple are configured

### DIFF
--- a/Resources/config/jackalope.xml
+++ b/Resources/config/jackalope.xml
@@ -53,7 +53,7 @@
                  public="false"
         >
             <argument type="collection"/>
-            <argument type="service" id="doctrine.dbal.default_connection"/>
+            <argument type="service" id="jackalope_doctrine_dbal.default_connection"/>
         </service>
 
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema_listener"


### PR DESCRIPTION
Cleaned up version of #273

Previous PR used ID `jackalope_doctrine_dbal.default_connection` instead of `doctrine_phpcr.jackalope_doctrine_dbal.default_connection`

Allows for multiple dbal connections and defining the connection to use in doctrine_phpcr:
```yaml
doctrine_phpcr:
    session:
        backend:
            connection: a_connection_name
```

`doctrine.dbal.default_connection` does not exist when multiple connections are defined like this for example:
```yaml
doctrine:
    dbal:
        default_connection: main
        connections:
            main:
                driver: pdo_mysql
                host: '%database_host%'
                port: '%database_port%'
                dbname: '%database_name%'
                user: '%database_user%'
                password: '%database_password%'
                charset: utf8mb4
                default_table_options:
                    charset: utf8mb4
                    collate: utf8mb4_unicode_ci
            secondary:
                driver: pdo_sqlite
                charset: utf8mb4
                default_table_options:
                    charset: utf8mb4
                    collate: utf8mb4_unicode_ci
                path: '%database_path%'
```