### PR TITLE
Add kernel root directory to fixtures location paths

### DIFF
--- a/Command/LoadFixtureCommand.php
+++ b/Command/LoadFixtureCommand.php
@@ -31,6 +31,7 @@ use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
 use InvalidArgumentException;
 use Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Command to load PHPCR-ODM fixtures.
@@ -135,10 +136,10 @@ EOT
         if ($dirOrFile) {
             $paths = is_array($dirOrFile) ? $dirOrFile : array($dirOrFile);
         } else {
-            /** @var $kernel \Symfony\Component\HttpKernel\KernelInterface */
+            /** @var $kernel KernelInterface */
             $kernel = $this->getApplication()->getKernel();
             $paths = array($kernel->getRootDir().'/DataFixtures/PHPCR');
-            foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
+            foreach ($kernel->getBundles() as $bundle) {
                 $paths[] = $bundle->getPath().'/DataFixtures/PHPCR';
             }
         }

--- a/Command/LoadFixtureCommand.php
+++ b/Command/LoadFixtureCommand.php
@@ -135,7 +135,9 @@ EOT
         if ($dirOrFile) {
             $paths = is_array($dirOrFile) ? $dirOrFile : array($dirOrFile);
         } else {
-            $paths = array();
+            /** @var $kernel \Symfony\Component\HttpKernel\KernelInterface */
+            $kernel = $this->getApplication()->getKernel();
+            $paths = array($kernel->getRootDir().'/DataFixtures/PHPCR');
             foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
                 $paths[] = $bundle->getPath().'/DataFixtures/PHPCR';
             }


### PR DESCRIPTION
This allows to load fixtures from a bundless application like the one created with symfony/flex. This is a port of https://github.com/doctrine/DoctrineFixturesBundle/pull/192.