### PR TITLE
Allow initializer services to be private

### DIFF
--- a/DependencyInjection/Compiler/InitializerPass.php
+++ b/DependencyInjection/Compiler/InitializerPass.php
@@ -22,7 +22,6 @@ namespace Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -45,11 +44,6 @@ class InitializerPass implements CompilerPassInterface
         $services = $container->findTaggedServiceIds('doctrine_phpcr.initializer');
 
         foreach ($services as $id => $attributes) {
-            $definition = $container->getDefinition($id);
-            if (!$definition->isPublic()) {
-                throw new LogicException(sprintf('initializer "%s" must be public', $id));
-            }
-
             $priority = 0;
 
             if (isset($attributes[0]['priority'])) {


### PR DESCRIPTION
Since #96, initializers no longer have to be public. This remove the hard check introduced in #50.