### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/Tests/Initializer/GenericInitializerTest.php
+++ b/Tests/Initializer/GenericInitializerTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Initializer;
 
 use Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer;
+use PHPUnit\Framework\TestCase;
 
-class GenericInitializerTest extends \PHPUnit_Framework_TestCase
+class GenericInitializerTest extends TestCase
 {
     protected $registry;
 

--- a/Tests/Unit/EventListener/LocaleListenerTest.php
+++ b/Tests/Unit/EventListener/LocaleListenerTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\EventListener\LocaleListenerTest;
 
 use Doctrine\Bundle\PHPCRBundle\EventListener\LocaleListener;
+use PHPUnit\Framework\TestCase;
 
-class LocaleListenerTest extends \PHPUnit_Framework_TestCase
+class LocaleListenerTest extends TestCase
 {
     private $chooser;
     private $responseEvent;

--- a/Tests/Unit/Form/DataTransformer/DocumentToPathTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/DocumentToPathTransformerTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\DocumentToPathTransformer;
+use PHPUnit\Framework\TestCase;
 
-class DocumentToPathTransformerTest extends \PHPUnit_Framework_Testcase
+class DocumentToPathTransformerTest extends Testcase
 {
     public function setUp()
     {

--- a/Tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToPathTransformer;
+use PHPUnit\Framework\TestCase;
 
-class PHPCRNodeToPathTransformerTest extends \PHPUnit_Framework_Testcase
+class PHPCRNodeToPathTransformerTest extends Testcase
 {
     public function setUp()
     {

--- a/Tests/Unit/Form/DataTransformer/PHPCRNodeToUuidTransformerTest.php
+++ b/Tests/Unit/Form/DataTransformer/PHPCRNodeToUuidTransformerTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToUuidTransformer;
+use PHPUnit\Framework\TestCase;
 
-class PHPCRNodeToUuidTransformerTest extends \PHPUnit_Framework_Testcase
+class PHPCRNodeToUuidTransformerTest extends Testcase
 {
     public function setUp()
     {

--- a/Tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
+++ b/Tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\DataTransformer;
 
 use Doctrine\Bundle\PHPCRBundle\Form\Type\PHPCRReferenceType;
+use PHPUnit\Framework\TestCase;
 
-class PHPCRReferenceTypeTest extends \PHPUnit_Framework_Testcase
+class PHPCRReferenceTypeTest extends Testcase
 {
     public function setUp()
     {

--- a/Tests/Unit/Form/Type/PathTypeTest.php
+++ b/Tests/Unit/Form/Type/PathTypeTest.php
@@ -5,9 +5,10 @@ namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Form\Type;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
 use Doctrine\Bundle\PHPCRBundle\Form\Type\PathType;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormBuilder;
 
-class PathTypeTest extends \PHPUnit_Framework_Testcase
+class PathTypeTest extends Testcase
 {
     /**
      * @var ManagerRegistry|\PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Unit/Initializer/InitializerManagerTest.php
+++ b/Tests/Unit/Initializer/InitializerManagerTest.php
@@ -3,8 +3,9 @@
 namespace Doctrine\Bundle\PHPCRBundle\Tests\Unit\Initializer;
 
 use Doctrine\Bundle\PHPCRBundle\Initializer\InitializerManager;
+use PHPUnit\Framework\TestCase;
 
-class InitializerManagerTest extends \PHPUnit_Framework_TestCase
+class InitializerManagerTest extends TestCase
 {
     public function setUp()
     {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpcr/phpcr-utils": "^1.2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "^4.8.36",
         "phpunit/php-code-coverage": "~2.2",
         "symfony/form": "~2.3|~3.0",
         "doctrine/phpcr-odm": "^1.3.0-rc4",


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).