### PR TITLE
Fixes paths of twig templates

### DIFF
--- a/src/Resources/config/phpcr.xml
+++ b/src/Resources/config/phpcr.xml
@@ -48,7 +48,7 @@
         <service id="doctrine_phpcr.data_collector"
                  class="Doctrine\Bundle\PHPCRBundle\DataCollector\PHPCRDataCollector"
                  public="false">
-            <tag name="data_collector" template="DoctrinePHPCRBundle:Collector:phpcr" id="phpcr" priority="247" />
+            <tag name="data_collector" template="DoctrinePHPCR/Collector/phpcr" id="phpcr" priority="247" />
             <argument type="service" id="doctrine_phpcr" />
         </service>
 

--- a/src/Resources/views/Collector/phpcr.html.twig
+++ b/src/Resources/views/Collector/phpcr.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.callcount > 0 %}
@@ -112,7 +112,7 @@
     <h2>Database Connections</h2>
 
     {% if collector.connections %}
-        {% include 'WebProfilerBundle:Profiler:table.html.twig' with {data: collector.connections} only %}
+        {% include '@WebProfiler/Profiler/table.html.twig' with {data: collector.connections} only %}
     {% else %}
         <div class="empty">
             <p>No connections.</p>
@@ -122,7 +122,7 @@
     <h2>Document Managers</h2>
 
     {% if collector.managers %}
-        {% include 'WebProfilerBundle:Profiler:table.html.twig' with {data: collector.managers} only %}
+        {% include '@WebProfiler/Profiler/table.html.twig' with {data: collector.managers} only %}
     {% else %}
         <div class="empty">
             <p>No document managers.</p>


### PR DESCRIPTION
Since the new syntax (`DoctrinePHPCR/Collector/phpcr.html.twig`) is already used in the templates, I updated the paths where the old syntax (`DoctrinePHPCRBundle:Collector:phpcr`) was used to ensure compatibility with symfony ^3.4 || ^4.0

Fixes #307 