### PR TITLE
Add missing @ in data collector template path

### DIFF
--- a/src/Resources/config/phpcr.xml
+++ b/src/Resources/config/phpcr.xml
@@ -48,7 +48,7 @@
         <service id="doctrine_phpcr.data_collector"
                  class="Doctrine\Bundle\PHPCRBundle\DataCollector\PHPCRDataCollector"
                  public="false">
-            <tag name="data_collector" template="DoctrinePHPCR/Collector/phpcr" id="phpcr" priority="247" />
+            <tag name="data_collector" template="@DoctrinePHPCR/Collector/phpcr" id="phpcr" priority="247" />
             <argument type="service" id="doctrine_phpcr" />
         </service>
 


### PR DESCRIPTION
As reported by @damienflament, I forgot a `@` in my previous PR #311 

Sorry about that.