### PR TITLE
re-add class parameters used by the doctrine bridge

### DIFF
--- a/src/Resources/config/odm.xml
+++ b/src/Resources/config/odm.xml
@@ -19,7 +19,9 @@
         <parameter key="doctrine_phpcr.odm.cache.memcached_port">11211</parameter>
         <parameter key="doctrine_phpcr.odm.cache.memcached_instance.class">Memcached</parameter>
         <parameter key="doctrine_phpcr.odm.cache.xcache.class">Doctrine\Common\Cache\XcacheCache</parameter>
-
+        <parameter key="doctrine_phpcr.odm.metadata.xml.class">Doctrine\Bundle\PHPCRBundle\Mapping\Driver\XmlDriver</parameter>
+        <parameter key="doctrine_phpcr.odm.metadata.yml.class">Doctrine\Bundle\PHPCRBundle\Mapping\Driver\YamlDriver</parameter>
+        <parameter key="doctrine_phpcr.odm.metadata.php.class">Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.driver_chain.class">Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.annotation.class">Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver</parameter>
     </parameters>


### PR DESCRIPTION
looks like #287 went too far, as the doctrine bridge relies on some of these parameters.