### PR TITLE
add app's document path to the mapped paths

### DIFF
--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -552,6 +552,13 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
             'is_bundle' => false,
             'mapping' => true,
         ];
+        $documentManager['mappings']['__App__'] = [
+            'dir' => dirname($container->getParameter('kernel.root_dir').'/Document'),
+            'type' => 'annotation',
+            'prefix' => 'App\Document',
+            'is_bundle' => false,
+            'mapping' => true,
+        ];
         $this->loadMappingInformation($documentManager, $container);
         $this->registerMappingDrivers($documentManager, $container);
 


### PR DESCRIPTION
With this PR the folder `src/Doument` which stands for `App\Document` is added to mapped paths for annotation driver.