### PR TITLE
Remove dependency on phpcr/phpcr-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpcr/phpcr-implementation": "2.1.*",
         "phpcr/phpcr-utils": "^1.3",
         "symfony/doctrine-bridge": "^2.8.18 || ^3.3 || ^4.0",
         "symfony/framework-bundle": "^2.8.18 || ^3.3 || ^4.0"

--- a/src/Form/Type/PHPCRReferenceType.php
+++ b/src/Form/Type/PHPCRReferenceType.php
@@ -23,7 +23,7 @@ class PHPCRReferenceType extends AbstractType
 {
     private $session;
 
-    public function __construct(SessionInterface $session)
+    public function __construct(SessionInterface $session = null)
     {
         $this->session = $session;
     }

--- a/src/Resources/config/phpcr.xml
+++ b/src/Resources/config/phpcr.xml
@@ -73,7 +73,7 @@
         <service id="form.type.phpcr.reference"
                  class="Doctrine\Bundle\PHPCRBundle\Form\Type\PHPCRReferenceType">
             <tag name="form.type" alias="phpcr_reference"/>
-            <argument type="service" id="doctrine_phpcr.session"/>
+            <argument type="service" id="doctrine_phpcr.session" on-invalid="null"/>
         </service>
 
         <service id="doctrine_phpcr.console_dumper"


### PR DESCRIPTION
With this PR it will be possible to create recipe for Symfony Flex for `doctrine/phpcr-bundle` (not for a pack). With these changes, this bundle will be installed into Flex application without errors during `cache:clear` command.

Recipe for `doctrine/phpcr-bundle` could be like this:

```yaml
doctrine_phpcr:
    odm:
        auto_mapping: true
        auto_generate_proxy_classes: true
```

If this PR will be accepted, after release it will be possible to create recipes for a packs for each `jackalope/jackalope-transport` package. New packs will require `doctrine/phpcr-bundle`, jackalope transport and `phpcr/phpcr-implementation`.

Recipe for a new pack with `jackalope/jackalope-doctrine-dbal` could be like this (i copied config from https://github.com/symfony/recipes-contrib/pull/326):

```yaml
doctrine_phpcr:
    session:
        backend:
            type: doctrinedbal
            connection: default
            parameters:
                jackalope.check_login_on_server: false
        workspace: '%env(PHPCR_WORKSPACE)%'
        username: '%env(PHPCR_USER)%'
        password: '%env(PHPCR_PASSWORD)%'
```
