### PR TITLE
`--max_line_length` option is ignored in NodeDumpCommand

### DIFF
--- a/src/Command/NodeDumpCommand.php
+++ b/src/Command/NodeDumpCommand.php
@@ -75,7 +75,7 @@ class NodeDumpCommand extends BaseDumpCommand implements ContainerAwareInterface
         $helperSet = $application->getHelperSet();
         $helperSet->set($this->consoleDumper);
 
-        if (!$input->getParameterOption('max_line_length')
+        if (!$input->hasOption('max_line_length')
             && $this->getContainer()->hasParameter('doctrine_phpcr.dump_max_line_length')
         ) {
             $input->setOption('max_line_length', $this->getContainer()->getParameter('doctrine_phpcr.dump_max_line_length'));

--- a/tests/Fixtures/App/DataFixtures/PHPCR/LoadData.php
+++ b/tests/Fixtures/App/DataFixtures/PHPCR/LoadData.php
@@ -59,6 +59,21 @@ class LoadData implements FixtureInterface
 
         $manager->persist($ref);
 
+        $doc = new TestDocument();
+        $doc->parent = $base;
+        $doc->nodename = 'doc-very-long';
+        $doc->bool = true;
+        $doc->date = new \DateTime('2014-01-14');
+        $doc->integer = 42;
+        $doc->long = 24;
+        $doc->number = 3.14;
+        $doc->text = 'Lorem ipsum dolor sit amet, consectetur adipiscing'.
+            ' elit. Aenean ultrices consectetur ex. Integer fringilla'.
+            ' augue sed lacus blandit, non aliquam leo dapibus. Sed'.
+            ' ac dolor lorem. Sed non ullamcorper nisl.';
+
+        $manager->persist($doc);
+
         $manager->flush();
 
         $node = $manager->getPhpcrSession()->getNode('/test/doc');

--- a/tests/Functional/Command/NodeDumpCommandTest.php
+++ b/tests/Functional/Command/NodeDumpCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\Bundle\PHPCRBundle\Tests\Functional\Command;
+
+use Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\DataFixtures\PHPCR\LoadData;
+use Doctrine\Bundle\PHPCRBundle\Tests\Functional\BaseTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class NodeDumpCommandTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $repositoryManager = $this->getRepositoryManager();
+        $repositoryManager->loadFixtures([LoadData::class]);
+    }
+
+    protected function getKernel()
+    {
+        if (!self::$kernel) {
+            self::bootKernel();
+        }
+        if (!self::$kernel->getContainer()) {
+            self::$kernel->boot();
+        }
+
+        return self::$kernel;
+    }
+
+    public function testMaxLineLengthOptionIsAppliedSuccessfully()
+    {
+        $application = new Application($this->getKernel());
+
+        $command = $application->find('doctrine:phpcr:node:dump');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--props' => true,
+            '--max_line_length' => 120,
+             'identifier' => '/test/doc-very-long',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertRegExp('/^\s+ - \s+ text \s+ = \s+ .{120} \.\.\.$/mx', $output);
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--props' => true,
+            '--max_line_length' => 20,
+            'identifier' => '/test/doc-very-long',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertRegExp('/^\s+ - \s+ text \s+ = \s+ .{20} \.\.\.$/mx', $output);
+    }
+}


### PR DESCRIPTION
I fixed it by changing `getParameterOption` to `hasOption` - I also added a functional test for it. 

The problem with `getParameterOption` is that it expects the raw parameter name (which would be `--max_line_length` instead of just `max_line_length`) so this check always returns false, even if the option is actually present. 

Any feedback is welcome!