### PR TITLE
Fix whole src/ dir included in mapping lookup

### DIFF
--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -502,13 +502,6 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
             'is_bundle' => false,
             'mapping' => true,
         ];
-        $documentManager['mappings']['__App__'] = [
-            'dir' => dirname($container->getParameter('kernel.root_dir').'/Document'),
-            'type' => 'annotation',
-            'prefix' => 'App\Document',
-            'is_bundle' => false,
-            'mapping' => true,
-        ];
         $this->loadMappingInformation($documentManager, $container);
         $this->registerMappingDrivers($documentManager, $container);
 


### PR DESCRIPTION
# Issue

With this issue, `App\Document\` namespace was looked up in directory:
- `src/`; other than
- `src/Document`

This also causes issue with Data Fixtures in some use cases where:
- Symfony is on `APP_ENV=prod` mode and composer install with `--no-dev`; and
- Data fixture which use `doctrine/doctrine-fixtures-bundle` (e.g., AppFixture) is located within `src/`

```php
// Running bin/console cache:warmup
PHP Fatal error:  Class 'Doctrine\Bundle\FixturesBundle\Fixture'
not found in src/symfony-project/src/DataFixtures/AppFixtures.php on line ??
```

As a result, this issue has similar symptom as shown in https://github.com/doctrine/DoctrineFixturesBundle/issues/225 but with different cause
