### PR TITLE
Fix problem with multiple mixed typed sessions when default is not a dbal session

### DIFF
--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -199,9 +199,9 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
                 $container->setAlias($connectionAliasName, $connectionService);
 
                 // If default connection does not exist set the first doctrine_dbal connection as default
-                $defaultConnectionAlias = sprintf('doctrine_phpcr%s.jackalope_doctrine_dbal.%s_connection', $serviceNamePrefix, 'default');
-                if (!$container->hasAlias($defaultConnectionAlias) && !$container->hasDefinition($defaultConnectionAlias)) {
-                    $container->setAlias($defaultConnectionAlias, $connectionAliasName);
+                $defaultConnectionName = sprintf('doctrine_phpcr%s.jackalope_doctrine_dbal.default_connection', $serviceNamePrefix);
+                if (!$container->hasAlias($defaultConnectionName)) {
+                    $container->setAlias($defaultConnectionName, $connectionAliasName);
                 }
 
                 if (!$this->dbalSchemaListenerLoaded) {

--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -44,10 +44,14 @@ use Symfony\Component\DependencyInjection\Reference;
 class DoctrinePHPCRExtension extends AbstractDoctrineExtension
 {
     private $defaultSession;
+
     private $sessions = array();
+
     private $bundleDirs = array();
+
     /** @var XmlFileLoader */
     private $loader;
+
     private $disableProxyWarmer = false;
 
     /**
@@ -193,6 +197,12 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
                 $connectionService = new Alias($connectionService, true);
                 $connectionAliasName = sprintf('doctrine_phpcr%s.jackalope_doctrine_dbal.%s_connection', $serviceNamePrefix, $session['name']);
                 $container->setAlias($connectionAliasName, $connectionService);
+
+                // If default connection does not exist set the first doctrine_dbal connection as default
+                $defaultConnectionAlias = sprintf('doctrine_phpcr%s.jackalope_doctrine_dbal.%s_connection', $serviceNamePrefix, 'default');
+                if (!$container->hasAlias($defaultConnectionAlias) && !$container->hasDefinition($defaultConnectionAlias)) {
+                    $container->setAlias($defaultConnectionAlias, $connectionAliasName);
+                }
 
                 if (!$this->dbalSchemaListenerLoaded) {
                     $this->loader->load('jackalope_doctrine_dbal.xml');


### PR DESCRIPTION
Currently the problem is that the following file is loaded once and has a hard reference the default connection: https://github.com/doctrine/DoctrinePHPCRBundle/blob/master/src/Resources/config/jackalope_doctrine_dbal.xml#L14

But if the default session is not a doctrine_dbal session the connection service doesn't exist thats why the services default should be set to the first dbal connection.

Example config where the error happens:

```yaml
doctrine_phpcr:
    session:
        sessions:
            default:
                backend:
                    type: jackrabbit
                    url: 'http://127.0.0.1:8080/server'
            live:
                backend:
                    type: jackrabbit
                    url: 'http://127.0.0.1:8080/server'
            migration:
                backend:
                    type: doctrinedbal
```