### PR TITLE
Avoid add multiple doctrine.event_listener tags with same options

### DIFF
--- a/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/DependencyInjection/DoctrinePHPCRExtension.php
@@ -44,10 +44,14 @@ use Symfony\Component\DependencyInjection\Reference;
 class DoctrinePHPCRExtension extends AbstractDoctrineExtension
 {
     private $defaultSession;
+
     private $sessions = array();
+
     private $bundleDirs = array();
+
     /** @var XmlFileLoader */
     private $loader;
+
     private $disableProxyWarmer = false;
 
     /**
@@ -198,14 +202,20 @@ class DoctrinePHPCRExtension extends AbstractDoctrineExtension
                     $this->loader->load('jackalope_doctrine_dbal.xml');
                     $this->dbalSchemaListenerLoaded = true;
                 }
-                $container
-                    ->getDefinition('doctrine_phpcr.jackalope_doctrine_dbal.schema_listener')
-                    ->addTag('doctrine.event_listener', array(
-                        'connection' => $connectionName,
-                        'event' => 'postGenerateSchema',
-                        'lazy' => true,
-                    ))
-                ;
+
+                $schemaListenerDefinition = $container->getDefinition('doctrine_phpcr.jackalope_doctrine_dbal.schema_listener');
+
+                $eventListenerOptions = array(
+                    'connection' => $connectionName,
+                    'event' => 'postGenerateSchema',
+                    'lazy' => true,
+                );
+
+                $schemaListenerTags = $schemaListenerDefinition->getTag('doctrine.event_listener');
+
+                if (!in_array($eventListenerOptions, $schemaListenerTags)) {
+                    $schemaListenerDefinition->addTag('doctrine.event_listener', $eventListenerOptions);
+                }
 
                 $backendParameters['jackalope.doctrine_dbal_connection'] = new Reference($connectionAliasName);
                 if (false === $admin && isset($session['backend']['caches'])) {


### PR DESCRIPTION
When having multiple sessions defined with the same connection the `doctrine.event_listener` is added multiple times. I think it should only be added once per configuration

> bin/console debug:container doctrine_phpcr.jackalope_doctrine_dbal.schema_listener

Before:

```
 ---------------- -------------------------------------------------------------------------------------
  Option           Value
 ---------------- -------------------------------------------------------------------------------------
  Service ID       doctrine_phpcr.jackalope_doctrine_dbal.schema_listener
  Class            Doctrine\Bundle\PHPCRBundle\EventListener\JackalopeDoctrineDbalSchemaListener
  Tags             doctrine.event_listener (connection: , event: postGenerateSchema, lazy: 1)
                   doctrine.event_listener (connection: , event: postGenerateSchema, lazy: 1)
                   doctrine.event_listener (connection: , event: postGenerateSchema, lazy: 1)
                   doctrine.event_listener (connection: , event: postGenerateSchema, lazy: 1)
                   doctrine.event_listener (connection: migration, event: postGenerateSchema, lazy: 1)
                   doctrine.event_listener (connection: migration, event: postGenerateSchema, lazy: 1)
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        no
  Autoconfigured   no
 ---------------- -------------------------------------------------------------------------------------
```

After:

```
 ---------------- -------------------------------------------------------------------------------------
  Option           Value
 ---------------- -------------------------------------------------------------------------------------
  Service ID       doctrine_phpcr.jackalope_doctrine_dbal.schema_listener
  Class            Doctrine\Bundle\PHPCRBundle\EventListener\JackalopeDoctrineDbalSchemaListener
  Tags             doctrine.event_listener (connection: , event: postGenerateSchema, lazy: 1)
                   doctrine.event_listener (connection: migration, event: postGenerateSchema, lazy: 1)
  Public           no
  Synthetic        no
  Lazy             no
  Shared           yes
  Abstract         no
  Autowired        no
  Autoconfigured   no
 ---------------- -------------------------------------------------------------------------------------
```