### PR TITLE
Fix tests on master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/phpcr-odm": "^1.4 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
-        "matthiasnoback/symfony-dependency-injection-test": "^2.2",
+        "matthiasnoback/symfony-dependency-injection-test": "^2.2 || ^3.0",
         "symfony/asset": "^3.4 || ^4.0",
         "symfony/browser-kit": "^3.4 || ^4.0",
         "symfony/css-selector": "^3.4 || ^4.0",

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -34,6 +34,6 @@ abstract class BaseTestCase extends WebTestCase
             $exception = $result->item(0)->nodeValue;
         }
 
-        $this->assertEquals(200, $response->getStatusCode(), $exception ? 'Exception: "'.$exception.'"' : null);
+        $this->assertEquals(200, $response->getStatusCode(), $exception ? 'Exception: "'.$exception.'"' : '');
     }
 }

--- a/tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
+++ b/tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
@@ -23,6 +23,8 @@ class DoctrinePHPCRExtensionTest extends AbstractExtensionTestCase
 
         $this->setParameter('kernel.name', 'app');
         $this->setParameter('kernel.root_dir', null);
+        $this->setParameter('kernel.project_dir', null);
+        $this->setParameter('kernel.container_class', null);
         $this->setParameter('kernel.environment', 'test');
         $this->setParameter('kernel.bundles', []);
         $this->setParameter('kernel.debug', false);


### PR DESCRIPTION
Currently some tests fail because some sub bundles are access kernel.project_dir and kernel.container_class parameter in there class. To avoid this problems they are now set in the test. Fix also assertEquals third parameter need to be a string when running tests on newer phpunit version.