### PR TITLE
mark schema listener as lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+unreleased
+----------
+
+* [performance] Jackalope Doctrine DBAL schema listener marked as lazy.
+  Install ocramius/proxy-manager to avoid unnecessary database calls.
+
 1.3.10
 ------
 

--- a/Resources/config/jackalope_doctrine_dbal.xml
+++ b/Resources/config/jackalope_doctrine_dbal.xml
@@ -14,6 +14,7 @@
         <service id="doctrine_phpcr.jackalope_doctrine_dbal.schema"
                  class="%doctrine_phpcr.jackalope_doctrine_dbal.repository_schema.class%"
                  public="false"
+                 lazy="true"
         >
             <argument type="collection"/>
             <argument type="service" id="doctrine_phpcr.jackalope_doctrine_dbal.default_connection"/>

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "jackalope/jackalope-doctrine-dbal": "if you want to use jackalope-doctrine-dbal. require version ^1.3",
         "doctrine/data-fixtures": "if you want to use the fixture loading.",
         "doctrine/doctrine-bundle": "when using jackalope-doctrine-dbal",
+        "ocramius/proxy-manager": "To avoid unnecessary database requests when using jackalope-doctrine-dbal",
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*"
     },
     "conflict": {


### PR DESCRIPTION
symfony automatically makes it lazy if ocramius/proxy-manager is available. otherwise the hint is ignored without causing any error.