### PR TITLE
allow rfc5646 formatted locales without workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Changelog
 =========
+2.1.1
+-----
+
+* [fix] Allow rfc5646 compatible locales without workaround
+  If you defined en-gb as locale in the config under `doctrine_phpcr.odm.locales` 
+  it would be converted to to en_gb by the symfony config key normalization.if
+  CAUTION: you did this before without applying a workaround of also defining en_gb
+  your installation will brake, see PR #347 for more details
 
 2.1.0
 -----

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -281,6 +281,7 @@ class Configuration implements ConfigurationInterface
 
         $root
             ->useAttributeAsKey('name')
+            ->normalizeKeys(false)
             ->prototype('array')
                 ->beforeNormalization()
                     ->ifTrue(function ($v) {


### PR DESCRIPTION
Currently its not possible to use the following configutation:
```yaml
doctrine_phpcr:
    odm:
        default_locale: nl-be
        locales:
            nl-be: [ ]
```

symfony will normalise the keys from nl-be
to nl_be by default. You can work around this issue
by defining nl_be and nl-be in which case no normalise
happens for nl-be

current possible workaround"

```yaml
doctrine_phpcr:
    odm:
        default_locale: nl-be
        locales:
            nl_be: [ 'nl-be' ]
            nl-be: [ ]
```

This change will brake installation that had this (mis)configured but used
it as nl_be anyways. 