### PR TITLE
Allow doctrine/persistence 2.0

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,9 +1,9 @@
 preset: symfony
 
+risky: true
+
 enabled:
   - combine_consecutive_unsets
-  - short_array_syntax
-  - newline_after_open_tag
   - no_php4_constructor
   - no_useless_else
   - ordered_use

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "conflict": {
         "doctrine/annotations": "< 1.7.0",
+        "doctrine/phpcr-odm": "< 1.5.2",
         "jackalope/jackalope": "< 1.3.1",
         "phpcr/phpcr-shell": "< 1.0.0-beta1",
         "symfony/dependency-injection": "4.0.0",
@@ -35,7 +36,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
-        "doctrine/phpcr-odm": "^1.4 || ^2.0",
+        "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.1",
         "symfony/asset": "^3.4 || ^4.3 || ^5.0",

--- a/src/CacheWarmer/UniqueNodeTypeCacheWarmer.php
+++ b/src/CacheWarmer/UniqueNodeTypeCacheWarmer.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\CacheWarmer;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Tools\Helper\UniqueNodeTypeHelper;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 /**

--- a/src/DataCollector/AbstractPHPCRDataCollector.php
+++ b/src/DataCollector/AbstractPHPCRDataCollector.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\DataCollector;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory;
+use Doctrine\Persistence\ManagerRegistry;
 use Jackalope\Query\Query;
 use Jackalope\Transport\Logging\DebugStack;
 use PHPCR\Query\QueryInterface;

--- a/src/DataCollector/AbstractPHPCRDataCollector.php
+++ b/src/DataCollector/AbstractPHPCRDataCollector.php
@@ -50,8 +50,7 @@ abstract class AbstractPHPCRDataCollector extends DataCollector
     /**
      * Adds the stack logger for a connection.
      *
-     * @param string     $name
-     * @param DebugStack $logger
+     * @param string $name
      */
     public function addLogger($name, DebugStack $logger)
     {
@@ -129,7 +128,7 @@ abstract class AbstractPHPCRDataCollector extends DataCollector
      */
     private function sanitizeParam($var): array
     {
-        if (is_object($var)) {
+        if (\is_object($var)) {
             if ($var instanceof QueryInterface) {
                 $query = [
                     'querystring' => $var->getStatement(),
@@ -143,10 +142,10 @@ abstract class AbstractPHPCRDataCollector extends DataCollector
                 return $query;
             }
 
-            return [sprintf('Object(%s)', get_class($var)), false];
+            return [sprintf('Object(%s)', \get_class($var)), false];
         }
 
-        if (is_array($var)) {
+        if (\is_array($var)) {
             $a = [];
             $original = true;
             foreach ($var as $k => $v) {
@@ -158,7 +157,7 @@ abstract class AbstractPHPCRDataCollector extends DataCollector
             return [$a, $original];
         }
 
-        if (is_resource($var)) {
+        if (\is_resource($var)) {
             return [sprintf('Resource(%s)', get_resource_type($var)), false];
         }
 

--- a/src/DependencyInjection/Compiler/DoctrinePhpcrMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrinePhpcrMappingsPass.php
@@ -2,12 +2,12 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler;
 
-use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
-use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
+use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;

--- a/src/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
+++ b/src/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
@@ -80,7 +80,7 @@ class PhpcrOdmQueryBuilderLoader implements EntityLoaderInterface
             return !empty($v);
         }));
 
-        if (0 === count($values)) {
+        if (0 === \count($values)) {
             return [];
         }
 
@@ -101,8 +101,6 @@ class PhpcrOdmQueryBuilderLoader implements EntityLoaderInterface
 
     /**
      * Run the query and return a consecutive array.
-     *
-     * @param QueryBuilder $qb
      *
      * @return array list of result documents
      */

--- a/src/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
+++ b/src/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\Form\ChoiceList;
 
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 

--- a/src/Form/DoctrinePHPCRExtension.php
+++ b/src/Form/DoctrinePHPCRExtension.php
@@ -11,7 +11,7 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\Form;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Form\AbstractExtension;
 
 class DoctrinePHPCRExtension extends AbstractExtension

--- a/src/Form/PhpcrOdmTypeGuesser.php
+++ b/src/Form/PhpcrOdmTypeGuesser.php
@@ -4,9 +4,9 @@ namespace Doctrine\Bundle\PHPCRBundle\Form;
 
 use Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType;
 use Doctrine\Bundle\PHPCRBundle\Form\Type\PathType;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;

--- a/src/Form/PhpcrOdmTypeGuesser.php
+++ b/src/Form/PhpcrOdmTypeGuesser.php
@@ -258,7 +258,7 @@ class PhpcrOdmTypeGuesser implements FormTypeGuesserInterface
 
     private function getMetadata($class): ?array
     {
-        if (array_key_exists($class, $this->cache)) {
+        if (\array_key_exists($class, $this->cache)) {
             return $this->cache[$class];
         }
 

--- a/src/Form/Type/DocumentType.php
+++ b/src/Form/Type/DocumentType.php
@@ -17,7 +17,7 @@
 namespace Doctrine\Bundle\PHPCRBundle\Form\Type;
 
 use Doctrine\Bundle\PHPCRBundle\Form\ChoiceList\PhpcrOdmQueryBuilderLoader;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 
 class DocumentType extends DoctrineType

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver as BaseXmlDriver;
+use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 
 /**
  * XmlDriver that additionally looks for mapping information in a global file.

--- a/src/Mapping/Driver/YamlDriver.php
+++ b/src/Mapping/Driver/YamlDriver.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver as BaseYamlDriver;
+use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 
 /**
  * YamlDriver that additionally looks for mapping information in a global file.

--- a/src/Resources/config/odm.xml
+++ b/src/Resources/config/odm.xml
@@ -21,8 +21,8 @@
         <parameter key="doctrine_phpcr.odm.cache.xcache.class">Doctrine\Common\Cache\XcacheCache</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.xml.class">Doctrine\Bundle\PHPCRBundle\Mapping\Driver\XmlDriver</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.yml.class">Doctrine\Bundle\PHPCRBundle\Mapping\Driver\YamlDriver</parameter>
-        <parameter key="doctrine_phpcr.odm.metadata.php.class">Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver</parameter>
-        <parameter key="doctrine_phpcr.odm.metadata.driver_chain.class">Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain</parameter>
+        <parameter key="doctrine_phpcr.odm.metadata.php.class">Doctrine\Persistence\Mapping\Driver\StaticPHPDriver</parameter>
+        <parameter key="doctrine_phpcr.odm.metadata.driver_chain.class">Doctrine\Persistence\Mapping\Driver\MappingDriverChain</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.annotation.class">Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver</parameter>
     </parameters>
     <services>

--- a/src/Test/RepositoryManager.php
+++ b/src/Test/RepositoryManager.php
@@ -7,8 +7,8 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/Fixtures/App/DataFixtures/PHPCR/LoadData.php
+++ b/tests/Fixtures/App/DataFixtures/PHPCR/LoadData.php
@@ -14,9 +14,9 @@ namespace Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\DataFixtures\PHPCR;
 use Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document\ReferrerDocument;
 use Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document\TestDocument;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Persistence\ObjectManager;
 
 class LoadData implements FixtureInterface
 {

--- a/tests/Functional/Form/PHPCRTypeGuesserTest.php
+++ b/tests/Functional/Form/PHPCRTypeGuesserTest.php
@@ -266,7 +266,7 @@ class PHPCRTypeGuesserTest extends BaseTestCase
 
         $formBuilder
             ->add('single', null, ['class' => ReferrerDocument::class])
-            ->add('documents', null, ['class' => ReferrerDocument::class])
+            ->add('documents', null, ['class' => TestDocument::class])
             ->add('testDocument')
             ->add('testDocuments')
         ;
@@ -286,7 +286,7 @@ class PHPCRTypeGuesserTest extends BaseTestCase
             [
                 'required' => false,
                 'multiple' => true,
-                'class' => ReferrerDocument::class,
+                'class' => TestDocument::class,
             ]
         );
 
@@ -362,10 +362,9 @@ class PHPCRTypeGuesserTest extends BaseTestCase
      * Assert that the form element has an inner type of type $typeClass and
      * the specified options with their values.
      *
-     * @param FormBuilderInterface $element
-     * @param string               $typeClass FQN class
-     * @param array                $options   keys are option names, values the
-     *                                        expected option values
+     * @param string $typeClass FQN class
+     * @param array  $options   keys are option names, values the
+     *                          expected option values
      */
     private function assertFormType(FormBuilderInterface $element, $typeClass, array $options)
     {

--- a/tests/Functional/Form/Type/DocumentTypeTest.php
+++ b/tests/Functional/Form/Type/DocumentTypeTest.php
@@ -66,8 +66,8 @@ class DocumentTypeTest extends BaseTestCase
         ;
 
         $html = $this->renderForm($formBuilder);
-        $this->assertContains('<select id="form_single" name="form[single]"', $html);
-        $this->assertContains('<option value="/test/doc"', $html);
+        $this->assertStringContainsString('<select id="form_single" name="form[single]"', $html);
+        $this->assertStringContainsString('<option value="/test/doc"', $html);
     }
 
     public function testFiltered()
@@ -87,7 +87,7 @@ class DocumentTypeTest extends BaseTestCase
         ;
 
         $html = $this->renderForm($formBuilder);
-        $this->assertContains('<select id="form_single" name="form[single]"', $html);
-        $this->assertNotContains('<option', $html);
+        $this->assertStringContainsString('<select id="form_single" name="form[single]"', $html);
+        $this->assertStringNotContainsString('<option', $html);
     }
 }

--- a/tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
+++ b/tests/Unit/DependencyInjection/DoctrinePHPCRExtensionTest.php
@@ -154,7 +154,7 @@ class DoctrinePHPCRExtensionTest extends AbstractExtensionTestCase
         $repositoryFactory = $this->container->getDefinition('doctrine_phpcr.jackalope.repository.default');
         $parameters = $repositoryFactory->getArgument(0);
 
-        $this->assertInternalType('array', $parameters);
+        $this->assertIsArray($parameters);
         $this->assertEquals([
             'jackalope.doctrine_dbal_connection',
             'jackalope.check_login_on_server',

--- a/tests/Unit/EventListener/LocaleListenerTest.php
+++ b/tests/Unit/EventListener/LocaleListenerTest.php
@@ -7,6 +7,7 @@ use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class LocaleListenerTest extends TestCase
 {
@@ -21,9 +22,18 @@ class LocaleListenerTest extends TestCase
     private function setUpTestOnKernelRequest()
     {
         $this->chooser = $this->createMock(LocaleChooser::class);
-        $this->responseEvent = $this->createMock(GetResponseEvent::class);
+        $this->responseEvent = $this->createMock($this->getResponseEventClass());
         $this->request = $this->createMock(Request::class);
         $this->allowedLocales = ['fr', 'en', 'de'];
+    }
+
+    private function getResponseEventClass(): string
+    {
+        if (class_exists(RequestEvent::class)) {
+            return RequestEvent::class;
+        }
+
+        return GetResponseEvent::class;
     }
 
     public function testOnKernelRequestWithFallbackHardcoded()

--- a/tests/Unit/Form/DataTransformer/DocumentToPathTransformerTest.php
+++ b/tests/Unit/Form/DataTransformer/DocumentToPathTransformerTest.php
@@ -7,6 +7,7 @@ use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\UnitOfWork;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class DocumentToPathTransformerTest extends Testcase
 {
@@ -48,15 +49,14 @@ class DocumentToPathTransformerTest extends Testcase
         $this->assertSame($this->document, $res);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
-     */
     public function testReverseTransformNotFound()
     {
         $this->dm->expects($this->once())
             ->method('find')
             ->with(null, '/asd')
             ->will($this->returnValue(null));
+
+        $this->expectException(TransformationFailedException::class);
 
         $res = $this->transformer->reverseTransform('/asd');
         $this->assertSame($this->document, $res);

--- a/tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
+++ b/tests/Unit/Form/DataTransformer/PHPCRNodeToPathTransformerTest.php
@@ -7,6 +7,7 @@ use Jackalope\Node;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class PHPCRNodeToPathTransformerTest extends Testcase
 {
@@ -43,11 +44,10 @@ class PHPCRNodeToPathTransformerTest extends Testcase
         $this->assertEquals('/asd', $res);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
     public function testTransformWrongType()
     {
+        $this->expectException(UnexpectedTypeException::class);
+
         $this->transformer->transform(new \stdClass());
     }
 

--- a/tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
+++ b/tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
@@ -37,7 +37,7 @@ class PHPCRReferenceTypeTest extends Testcase
         $this->builder->expects($this->once())
             ->method('addModelTransformer')
             ->will($this->returnCallback(function ($transformer) use (&$type) {
-                $type = get_class($transformer);
+                $type = \get_class($transformer);
 
                 return;
             }));

--- a/tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
+++ b/tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
@@ -7,6 +7,7 @@ use Doctrine\Bundle\PHPCRBundle\Form\DataTransformer\PHPCRNodeToUuidTransformer;
 use Doctrine\Bundle\PHPCRBundle\Form\Type\PHPCRReferenceType;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\FormBuilder;
 
 class PHPCRReferenceTypeTest extends Testcase
@@ -46,11 +47,10 @@ class PHPCRReferenceTypeTest extends Testcase
         $this->assertEquals($transformerFqn, $type);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testInvalidType()
     {
+        $this->expectException(InvalidConfigurationException::class);
+
         $this->type->buildForm($this->builder, ['transformer_type' => 'asdasd']);
     }
 }

--- a/tests/Unit/Initializer/InitializerManagerTest.php
+++ b/tests/Unit/Initializer/InitializerManagerTest.php
@@ -111,7 +111,7 @@ class InitializerManagerTest extends TestCase
 
         // check expected order against the log
         foreach ($expectedOrder as $i => $initializerVar) {
-            $this->assertContains($initializerVar, $log[$i]);
+            $this->assertStringContainsString($initializerVar, $log[$i]);
         }
     }
 

--- a/tests/Unit/Initializer/InitializerManagerTest.php
+++ b/tests/Unit/Initializer/InitializerManagerTest.php
@@ -107,7 +107,7 @@ class InitializerManagerTest extends TestCase
 
         $this->initializerManager->initialize();
 
-        $this->assertCount(count($initializers), $log);
+        $this->assertCount(\count($initializers), $log);
 
         // check expected order against the log
         foreach ($expectedOrder as $i => $initializerVar) {


### PR DESCRIPTION
Requires explicitly doctrine/persistence package and changes namespace to be compatible with version 2.0.