### PR TITLE
Add possibility to implement a query cache

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -180,6 +180,7 @@ class Configuration implements ConfigurationInterface
                                 ->children()
                                     ->scalarNode('meta')->end()
                                     ->scalarNode('nodes')->end()
+                                    ->scalarNode('query')->end()
                                 ->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
There seems a query cache implemented in the doctrine dbal [CachedClient](https://github.com/jackalope/jackalope-doctrine-dbal/blob/85980bc641c3c8024823d791465471885babf56a/src/Jackalope/Transport/DoctrineDBAL/CachedClient.php#L592) but actually it is not possible to configured it over the repository.

Had this a specific case, was there any issues with invalidation or why this was not implemented? There seems to be an issue here https://github.com/doctrine/DoctrinePHPCRBundle/issues/4 whichs links to https://github.com/doctrine/phpcr-odm/issues/427 but actually it seems we are not using `doctrine/phpcr-odm` package or atleast my composer doesn't output it. 