### PR TITLE
this bundle depends on doctrine/cache

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -18,19 +18,6 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: "7.1"
-                      phpunit-version: "6.5"
-                      dependencies: "lowest"
-
-                    - php-version: "7.1"
-                      phpunit-version: "6.5"
-
-                    - php-version: "7.2"
-                      phpunit-version: "8.5"
-
-                    - php-version: "7.3"
-                      phpunit-version: "8.5"
-
                     - php-version: "7.4"
                       phpunit-version: "6.5"
                       dependencies: "lowest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.3.0
+-----
+
+* Explicitly require doctrine/cache to keep running Jackalope with cache.
+* Drop support for PHP 7.1 - 7.3
+
 2.2.2
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.4|^8.0",
         "phpcr/phpcr-utils": "^1.3",
         "symfony/doctrine-bridge": "^3.4 || ^4.3 || ^5.0",
-        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0"
+        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
+        "doctrine/cache": "^1.12"
     },
     "conflict": {
         "doctrine/annotations": "< 1.7.0",

--- a/tests/Fixtures/App/config/framework.yaml
+++ b/tests/Fixtures/App/config/framework.yaml
@@ -1,5 +1,7 @@
 framework:
     secret: test
+    annotations: ~
+    property_access: ~
     test: ~
     form: ~
     router:


### PR DESCRIPTION
this used to be pulled in automatically but now that doctrine/cache is
abandoned, it is no longer pulled in automatically.

we should switch to PSR-6 or PSR-16 cache and use e.g. symfony/cache,
but jackalope depends on doctrine cache directly for now.