### PR TITLE
Allow symfony 6

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -19,14 +19,8 @@ jobs:
             matrix:
                 include:
                     - php-version: "7.4"
-                      phpunit-version: "6.5"
+                      phpunit-version: "8.5"
                       dependencies: "lowest"
-
-                    - php-version: "7.4"
-                      phpunit-version: "7.5"
-                      dependencies: "lowest"
-                      composer-require: "matthiasnoback/symfony-dependency-injection-test:^3.0"
-                      symfony-version: "^3.4"
 
                     - php-version: "7.4"
                       phpunit-version: "8.5"
@@ -38,7 +32,11 @@ jobs:
                       symfony-version: "5.0.*"
 
                     - php-version: "8.0"
-                      phpunit-version: "8.5"
+                      phpunit-version: "9.5"
+                      symfony-version: "6.0.*"
+
+                    - php-version: "8.0"
+                      phpunit-version: "9.5"
 
         steps:
             - name: "Checkout project"

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -1,0 +1,11 @@
+UPGRADE FROM 2.x to 2.3
+=======================
+
+* [BC Break] In order to have compatibility with Symfony 6, return types have been added to the following methods:
+    * `Doctrine\Bundle\PHPCRBundle\DependencyInjection\DoctrinePHPCRExtension::getMappingObjectDefaultName()`
+    * `Doctrine\Bundle\PHPCRBundle\DependencyInjection\DoctrinePHPCRExtension::getMappingResourceConfigDirectory()`
+    * `Doctrine\Bundle\PHPCRBundle\DependencyInjection\DoctrinePHPCRExtension::getMappingResourceExtension()`
+    * `Doctrine\Bundle\PHPCRBundle\DependencyInjection\DoctrinePHPCRExtension::getObjectManagerElementName()`
+    * `Doctrine\Bundle\PHPCRBundle\Form\ChoiceList\PhpcrOdmQueryBuilderLoader::getEntities`
+    * `Doctrine\Bundle\PHPCRBundle\Form\ChoiceList\PhpcrOdmQueryBuilderLoader::getEntitiesByIds`
+    * `Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType::getLoader`

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/asset": "^4.3 || ^5.0 || ^6.0",
         "symfony/browser-kit": "^4.3 || ^5.0 || ^6.0",
         "symfony/css-selector": "^4.3 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.4|^8.0",
         "phpcr/phpcr-utils": "^1.3",
-        "symfony/doctrine-bridge": "^3.4 || ^4.3 || ^5.0",
-        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
+        "symfony/doctrine-bridge": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
         "doctrine/cache": "^1.12"
     },
     "conflict": {
@@ -40,19 +40,19 @@
         "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.1",
-        "symfony/asset": "^3.4 || ^4.3 || ^5.0",
-        "symfony/browser-kit": "^3.4 || ^4.3 || ^5.0",
-        "symfony/css-selector": "^3.4 || ^4.3 || ^5.0",
+        "symfony/asset": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/browser-kit": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/css-selector": "^3.4 || ^4.3 || ^5.0 || ^6.0",
         "symfony/debug": "^3.4 || ^4.3 || ^5.0",
-        "symfony/form": "^3.4 || ^4.3 || ^5.0",
-        "symfony/monolog-bridge": "^3.4 || ^4.3 || ^5.0",
-        "symfony/monolog-bundle": "^3.4 || ^4.3 || ^5.0",
-        "symfony/phpunit-bridge": "^5.2",
-        "symfony/templating": "^3.4 || ^4.3 || ^5.0",
-        "symfony/translation": "^3.4 || ^4.3 || ^5.0",
-        "symfony/twig-bundle": "^3.4 || ^4.3 || ^5.0",
-        "symfony/validator": "^3.4 || ^4.3 || ^5.0",
-        "symfony/web-profiler-bundle": "^3.4 || ^4.3 || ^5.0"
+        "symfony/form": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/monolog-bridge": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/monolog-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^5.4",
+        "symfony/templating": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/translation": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/twig-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/validator": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/web-profiler-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0"
     },
     "suggest": {
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.4|^8.0",
         "phpcr/phpcr-utils": "^1.3",
-        "symfony/doctrine-bridge": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/doctrine-bridge": "^4.3 || ^5.0 || ^6.0",
+        "symfony/framework-bundle": "^4.3 || ^5.0 || ^6.0",
         "doctrine/cache": "^1.12"
     },
     "conflict": {
@@ -40,19 +40,19 @@
         "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.1",
-        "symfony/asset": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/browser-kit": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/css-selector": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/debug": "^3.4 || ^4.3 || ^5.0",
-        "symfony/form": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/monolog-bridge": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/monolog-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/asset": "^4.3 || ^5.0 || ^6.0",
+        "symfony/browser-kit": "^4.3 || ^5.0 || ^6.0",
+        "symfony/css-selector": "^4.3 || ^5.0 || ^6.0",
+        "symfony/error-handler": "^4.4 || ^5.0  || ^6.0",
+        "symfony/form": "^4.3 || ^5.0 || ^6.0",
+        "symfony/monolog-bridge": "^4.3 || ^5.0 || ^6.0",
+        "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^5.4",
-        "symfony/templating": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/translation": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/twig-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/validator": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-        "symfony/web-profiler-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0"
+        "symfony/templating": "^4.3 || ^5.0 || ^6.0",
+        "symfony/translation": "^4.3 || ^5.0 || ^6.0",
+        "symfony/twig-bundle": "^4.3 || ^5.0 || ^6.0",
+        "symfony/validator": "^4.3 || ^5.0 || ^6.0",
+        "symfony/web-profiler-bundle": "^4.3 || ^5.0 || ^6.0"
     },
     "suggest": {
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*",

--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -487,12 +487,12 @@ abstract class BaseDoctrinePHPCRExtension extends AbstractDoctrineExtension
     /**
      * {@inheritdoc}
      */
-    protected function getMappingDriverBundleConfigDefaults(array $bundleConfig, \ReflectionClass $bundle, ContainerBuilder $container)
-    {
-        $this->bundleDirs[] = \dirname($bundle->getFileName());
-
-        return parent::getMappingDriverBundleConfigDefaults($bundleConfig, $bundle, $container);
-    }
+//    protected function getMappingDriverBundleConfigDefaults(array $bundleConfig, \ReflectionClass $bundle, ContainerBuilder $container)
+//    {
+//        $this->bundleDirs[] = \dirname($bundle->getFileName());
+//
+//        return parent::getMappingDriverBundleConfigDefaults($bundleConfig, $bundle, $container);
+//    }
 
     private function loadOdmDocumentManagerMappingInformation(array $documentManager, Definition $odmConfig, ContainerBuilder $container)
     {
@@ -534,7 +534,7 @@ abstract class BaseDoctrinePHPCRExtension extends AbstractDoctrineExtension
     /**
      * {@inheritdoc}
      */
-    protected function getMappingObjectDefaultName()
+    protected function getMappingObjectDefaultName(): string
     {
         return 'Document';
     }
@@ -542,7 +542,7 @@ abstract class BaseDoctrinePHPCRExtension extends AbstractDoctrineExtension
     /**
      * {@inheritdoc}
      */
-    protected function getMappingResourceConfigDirectory()
+    protected function getMappingResourceConfigDirectory(string $bundleDir = null): string
     {
         return 'Resources/config/doctrine';
     }
@@ -550,7 +550,7 @@ abstract class BaseDoctrinePHPCRExtension extends AbstractDoctrineExtension
     /**
      * {@inheritdoc}
      */
-    protected function getMappingResourceExtension()
+    protected function getMappingResourceExtension(): string
     {
         return 'phpcr';
     }
@@ -578,7 +578,7 @@ if ($refl->hasMethod('getMetadataDriverClass') && $refl->getMethod('getMetadataD
         /**
          * {@inheritdoc}
          */
-        protected function getObjectManagerElementName(string $name)
+        protected function getObjectManagerElementName(string $name): string
         {
             return 'doctrine_phpcr.odm.'.$name;
         }

--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -36,11 +36,6 @@ abstract class BaseDoctrinePHPCRExtension extends AbstractDoctrineExtension
     private $sessions = [];
 
     /**
-     * @var string[]
-     */
-    private $bundleDirs = [];
-
-    /**
      * @var XmlFileLoader
      */
     private $loader;
@@ -483,16 +478,6 @@ abstract class BaseDoctrinePHPCRExtension extends AbstractDoctrineExtension
             $documentManagerDefinition->addMethodCall('setTranslationStrategy', [$name, new Reference($strategyId)]);
         }
     }
-
-    /**
-     * {@inheritdoc}
-     */
-//    protected function getMappingDriverBundleConfigDefaults(array $bundleConfig, \ReflectionClass $bundle, ContainerBuilder $container)
-//    {
-//        $this->bundleDirs[] = \dirname($bundle->getFileName());
-//
-//        return parent::getMappingDriverBundleConfigDefaults($bundleConfig, $bundle, $container);
-//    }
 
     private function loadOdmDocumentManagerMappingInformation(array $documentManager, Definition $odmConfig, ContainerBuilder $container)
     {

--- a/src/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
+++ b/src/Form/ChoiceList/PhpcrOdmQueryBuilderLoader.php
@@ -59,7 +59,7 @@ class PhpcrOdmQueryBuilderLoader implements EntityLoaderInterface
      *
      * @return array the documents
      */
-    public function getEntities()
+    public function getEntities(): array
     {
         return $this->getResult($this->queryBuilder);
     }
@@ -74,7 +74,7 @@ class PhpcrOdmQueryBuilderLoader implements EntityLoaderInterface
      *
      * @return array the entities
      */
-    public function getEntitiesByIds($identifier, array $values)
+    public function getEntitiesByIds($identifier, array $values): array
     {
         $values = array_values(array_filter($values, function ($v) {
             return !empty($v);

--- a/src/Form/Type/DocumentType.php
+++ b/src/Form/Type/DocumentType.php
@@ -18,6 +18,7 @@ namespace Doctrine\Bundle\PHPCRBundle\Form\Type;
 
 use Doctrine\Bundle\PHPCRBundle\Form\ChoiceList\PhpcrOdmQueryBuilderLoader;
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 
 class DocumentType extends DoctrineType
@@ -25,7 +26,7 @@ class DocumentType extends DoctrineType
     /**
      * {@inheritdoc}
      */
-    public function getLoader(ObjectManager $manager, $queryBuilder, $class)
+    public function getLoader(ObjectManager $manager, $queryBuilder, $class): EntityLoaderInterface
     {
         return new PhpcrOdmQueryBuilderLoader(
             $queryBuilder,

--- a/tests/Fixtures/App/Kernel.php
+++ b/tests/Fixtures/App/Kernel.php
@@ -7,22 +7,22 @@ use Symfony\Component\HttpKernel\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
 {
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return __DIR__.'/var/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return __DIR__.'/var/log';
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         $contents = require __DIR__.'/config/bundles.php';
         foreach ($contents as $class => $envs) {

--- a/tests/Fixtures/App/bin/console
+++ b/tests/Fixtures/App/bin/console
@@ -4,7 +4,7 @@
 use Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 
 require __DIR__.'/../../../../vendor/autoload.php';
 

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\PHPCRBundle\Tests\Functional;
 
 use Doctrine\Bundle\PHPCRBundle\Test\RepositoryManager;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class BaseTestCase extends WebTestCase
@@ -17,7 +18,7 @@ abstract class BaseTestCase extends WebTestCase
             self::$kernel->boot();
         }
 
-        return new RepositoryManager(self::$kernel->getContainer());
+        return new RepositoryManager(self::getTestContainer());
     }
 
     protected function assertResponseSuccess(Response $response)
@@ -35,5 +36,21 @@ abstract class BaseTestCase extends WebTestCase
         }
 
         $this->assertEquals(200, $response->getStatusCode(), $exception ? 'Exception: "'.$exception.'"' : '');
+    }
+
+    protected static function getTestContainer(): ContainerInterface
+    {
+        if (!self::$kernel) {
+            self::bootKernel();
+        }
+        if (!self::$kernel->getContainer()) {
+            self::$kernel->boot();
+        }
+
+        if (method_exists(self::class, 'getContainer')) {
+            return self::getContainer();
+        }
+
+        return self::$container;
     }
 }

--- a/tests/Functional/Command/NodeDumpCommandTest.php
+++ b/tests/Functional/Command/NodeDumpCommandTest.php
@@ -11,6 +11,8 @@ class NodeDumpCommandTest extends BaseTestCase
 {
     public function setUp(): void
     {
+        self::bootKernel();
+
         $repositoryManager = $this->getRepositoryManager();
         $repositoryManager->loadFixtures([LoadData::class]);
     }

--- a/tests/Functional/Form/ChoiceList/PhpcrOdmQueryBuilderLoaderTest.php
+++ b/tests/Functional/Form/ChoiceList/PhpcrOdmQueryBuilderLoaderTest.php
@@ -18,6 +18,8 @@ class PhpcrOdmQueryBuilderLoaderTest extends BaseTestCase
 
     public function setUp(): void
     {
+        self::bootKernel();
+
         $repositoryManager = $this->getRepositoryManager();
         $repositoryManager->loadFixtures([LoadData::class]);
 

--- a/tests/Functional/Form/PHPCRTypeGuesserTest.php
+++ b/tests/Functional/Form/PHPCRTypeGuesserTest.php
@@ -53,7 +53,7 @@ class PHPCRTypeGuesserTest extends BaseTestCase
      */
     private function createFormBuilder($data, $options = [])
     {
-        return self::$kernel->getContainer()->get('form.factory')->createBuilder(FormType::class, $data, $options);
+        return self::getTestContainer()->get('form.factory')->createBuilder(FormType::class, $data, $options);
     }
 
     public function testFields()
@@ -354,7 +354,7 @@ class PHPCRTypeGuesserTest extends BaseTestCase
     {
         $formView = $formBuilder->getForm()->createView();
         /** @var Environment $twig */
-        $twig = self::$kernel->getContainer()->get('twig');
+        $twig = self::getTestContainer()->get('twig');
         $twig->render('form.html.twig', ['form' => $formView]);
     }
 

--- a/tests/Functional/Form/Type/DocumentTypeTest.php
+++ b/tests/Functional/Form/Type/DocumentTypeTest.php
@@ -26,6 +26,8 @@ class DocumentTypeTest extends BaseTestCase
 
     public function setUp(): void
     {
+        self::bootKernel();
+
         $repositoryManager = $this->getRepositoryManager();
         $repositoryManager->loadFixtures([LoadData::class]);
         $this->dm = $repositoryManager->getDocumentManager();
@@ -40,7 +42,7 @@ class DocumentTypeTest extends BaseTestCase
      */
     private function createFormBuilder($data, $options = [])
     {
-        return self::$kernel->getContainer()->get('form.factory')->createBuilder(FormType::class, $data, $options);
+        return self::getTestContainer()->get('form.factory')->createBuilder(FormType::class, $data, $options);
     }
 
     /**
@@ -50,7 +52,7 @@ class DocumentTypeTest extends BaseTestCase
     {
         $formView = $formBuilder->getForm()->createView();
         /** @var Environment $twig */
-        $twig = self::$kernel->getContainer()->get('twig');
+        $twig = self::getTestContainer()->get('twig');
 
         return $twig->render('form.html.twig', ['form' => $formView]);
     }

--- a/tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
+++ b/tests/Unit/Form/Type/PHPCRReferenceTypeTest.php
@@ -40,7 +40,7 @@ class PHPCRReferenceTypeTest extends Testcase
             ->will($this->returnCallback(function ($transformer) use (&$type) {
                 $type = \get_class($transformer);
 
-                return;
+                return $this->builder;
             }));
         $this->type->buildForm($this->builder, ['transformer_type' => $transformerType]);
 

--- a/tests/Unit/Form/Type/PathTypeTest.php
+++ b/tests/Unit/Form/Type/PathTypeTest.php
@@ -64,7 +64,7 @@ class PathTypeTest extends Testcase
                     $transformer
                 );
 
-                return;
+                return $this->builder;
             }));
 
         $this->type->buildForm($this->builder, ['manager_name' => null]);


### PR DESCRIPTION
This PR adds symfony 6 support and needs to drop symfony 3.4 support because of incompatibilities in dependencies (symfony/debug vs symfony/error-handler)

I also needed to add some typehints for symfony 6, which are actually BC breaks on the form classes. But I've based my changes on this PR where the BC-breaks were allow but documented on the changelog. https://github.com/doctrine/DoctrineMongoDBBundle/pull/710/files#diff-ac283054e672754976fb16579fe1793963bb79c2410f0c6e0718d5dda58104a2R16