### PR TITLE
remove obsolete PHPCRODMReferenceCollectionType service definition

### DIFF
--- a/src/Resources/config/odm.xml
+++ b/src/Resources/config/odm.xml
@@ -58,12 +58,6 @@
             public="true"
         />
 
-        <service id="form.type.phpcr_odm.reference_collection"
-                 class="Doctrine\Bundle\PHPCRBundle\Form\Type\PHPCRODMReferenceCollectionType">
-            <tag name="form.type" alias="phpcr_odm_reference_collection"/>
-            <argument type="service" id="doctrine_phpcr.odm.document_manager"/>
-        </service>
-
         <service id="form.type.phpcr.document"
                  class="Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType">
             <tag name="form.type" alias="phpcr_document"/>


### PR DESCRIPTION
this form type has been removed for version 3 of the bundle. remove the service definition to avoid warnings from the container linter.

fix #364 