### PR TITLE
build with php 8.3 and symfony 7 dev

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -17,14 +17,10 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: "7.4"
-                      phpunit-version: "8.5"
-                      dependencies: "lowest"
-
-                    - php-version: "7.4"
-                      phpunit-version: "8.5"
+                    - php-version: "8.0"
+                      phpunit-version: "9.5"
                       phpunit-flags: "-v --coverage-text"
-                      symfony-version: "^5.4"
+                      symfony-version: "6.0.*"
 
                     - php-version: "8.0"
                       phpunit-version: "9.5"
@@ -36,9 +32,13 @@ jobs:
                     - php-version: "8.2"
                       phpunit-version: "9.5"
 
+                    - php-version: "8.3"
+                      phpunit-version: "9.5"
+                      symfony-version: "7.*"
+
         steps:
             - name: "Checkout project"
-              uses: "actions/checkout@v3"
+              uses: "actions/checkout@v4"
 
             - name: "Install and configure PHP"
               uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -12,18 +12,16 @@ jobs:
     test:
         name: "PHP ${{ matrix.php-version }}, Symfony ${{ matrix.symfony-version }}"
         runs-on: "ubuntu-20.04"
+        env:
+          SYMFONY_REQUIRE: ${{matrix.symfony-require}}
 
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: "8.0"
+                    - php-version: "8.1"
                       phpunit-version: "9.5"
                       phpunit-flags: "-v --coverage-text"
-                      symfony-version: "6.0.*"
-
-                    - php-version: "8.0"
-                      phpunit-version: "9.5"
                       symfony-version: "6.0.*"
 
                     - php-version: "8.1"
@@ -47,11 +45,13 @@ jobs:
                   extensions: "pdo, pdo_sqlite"
                   tools: "composer:v2"
 
-            - name: "Require Specific Symfony Version"
+            - name: "Require specific symfony version"
               if: "${{ matrix.symfony-version }}"
-              run: "composer require --no-update symfony/symfony:${{ matrix.symfony-version }}"
+              run: |
+                composer require --no-update symfony/flex
+                composer config --no-plugins allow-plugins.symfony/flex true
 
-            - name: "Require Additional dependencies"
+            - name: "Require additional dependencies"
               if: "${{ matrix.composer-require }}"
               run: "composer require --no-update ${{ matrix.composer-require }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
   The configuration of metadata_cache_driver changed. By default, it creates an `array` cache.
   To configure a service, specify `type: service` and specify your service in the `id` property.
   To use a cache pool, specify the service id of that pool.
+* Removed support for namespace alias, use the FQN names.
 * Introduced the ManagerRegistryInterface for the ManagerRegistry and adjusted the service alias for autowiring to the interface.  
 * The following container parameters are no longer taken into account (memcache and apc seem to have never been used anyways).
   If you have customised the array cache class, please check if this is still needed - and note that starting from this version,
@@ -27,6 +28,7 @@ Changelog
     doctrine_phpcr.odm.cache.memcached_port
     doctrine_phpcr.odm.cache.memcached_instance.class
     doctrine_phpcr.odm.cache.xcache.class
+
 * If no username is defined for a session, and if you use Jackalope >= 2.0, the
   credentials service for this session is no longer created and `null` is
   passed as credentials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 * Upgrade to phpcr-odm 2.0
 * Support jackalope 2.0
+* Drop support for PHP 7
 * Replace doctrine cache with PSR-6 cache with the symfony/cache implementation.
   The configuration of metadata_cache_driver changed. By default, it creates an `array` cache.
   To configure a service, specify `type: service` and specify your service in the `id` property.

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": "^8.0",
+        "ext-dom": "*",
         "phpcr/phpcr-utils": "^1.3 || ^2.0",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
@@ -37,14 +38,14 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.0.3",
-        "doctrine/phpcr-odm": "^2.0",
+        "doctrine/phpcr-odm": "2.x-dev",
         "doctrine/orm": "^2.0 || ^3.0",
         "jackalope/jackalope-doctrine-dbal": "^2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3.1 || ^5.0",
         "symfony/asset": "^5.4 || ^6.0 || ^7.0",
         "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
-        "symfony/error-handler": "^4.4 || ^5.0  || ^6.0",
+        "symfony/error-handler": "^5.4  || ^6.0 || ^7.0",
         "symfony/form": "^5.4 || ^6.0 || ^7.0",
         "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/monolog-bundle": "^3.4",
@@ -82,5 +83,5 @@
         }
     },
     "prefer-stable": true,
-    "minimum-stability": "dev"
+    "minimum-stability": "beta"
 }

--- a/composer.json
+++ b/composer.json
@@ -21,36 +21,39 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "phpcr/phpcr-utils": "^1.3",
-        "symfony/doctrine-bridge": "^5.4 || ^6.0",
-        "symfony/framework-bundle": "^5.4 || ^6.0",
-        "symfony/cache": "^5.4 || ^6.0"
+        "php": "^8.0",
+        "phpcr/phpcr-utils": "^1.3 || ^2.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
+        "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {
         "doctrine/annotations": "< 1.7.0",
         "doctrine/doctrine-bundle": "< 2.0.3",
         "jackalope/jackalope": "< 1.3.1",
-        "phpcr/phpcr-shell": "< 1.0.0-beta1"
+        "phpcr/phpcr-shell": "< 1.0.0-beta1",
+        "symfony/dependency-injection": "< 3",
+        "symfony/console": "< 4"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.0.3",
         "doctrine/phpcr-odm": "^2.0",
-        "jackalope/jackalope-doctrine-dbal": "^1.3 || ^2.0",
+        "doctrine/orm": "^2.0 || ^3.0",
+        "jackalope/jackalope-doctrine-dbal": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "symfony/asset": "^5.4 || ^6.0",
-        "symfony/browser-kit": "^5.4 || ^6.0",
-        "symfony/css-selector": "^5.4 || ^6.0",
+        "symfony/asset": "^5.4 || ^6.0 || ^7.0",
+        "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
+        "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
         "symfony/error-handler": "^4.4 || ^5.0  || ^6.0",
-        "symfony/form": "^5.4 || ^6.0",
-        "symfony/monolog-bridge": "^5.4 || ^6.0",
+        "symfony/form": "^5.4 || ^6.0 || ^7.0",
+        "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^v6.4.2 || ^v7.0.2",
-        "symfony/templating": "^5.4 || ^6.0",
-        "symfony/translation": "^5.4 || ^6.0",
-        "symfony/twig-bundle": "^5.4 || ^6.0",
-        "symfony/validator": "^5.4 || ^6.0",
-        "symfony/web-profiler-bundle": "^5.4 || ^6.0"
+        "symfony/templating": "^5.4 || ^6.0 || ^7.0",
+        "symfony/translation": "^5.4 || ^6.0 || ^7.0",
+        "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
+        "symfony/validator": "^5.4 || ^6.0 || ^7.0",
+        "symfony/web-profiler-bundle": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
         "burgov/key-value-form-bundle": "to edit assoc multivalue properties. require version 1.0.*",
@@ -78,5 +81,6 @@
             "Doctrine\\Bundle\\PHPCRBundle\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "beta"
+    "prefer-stable": true,
+    "minimum-stability": "dev"
 }

--- a/src/CacheWarmer/UniqueNodeTypeCacheWarmer.php
+++ b/src/CacheWarmer/UniqueNodeTypeCacheWarmer.php
@@ -29,12 +29,14 @@ final class UniqueNodeTypeCacheWarmer implements CacheWarmerInterface
         return true;
     }
 
-    public function warmUp($cacheDir): void
+    public function warmUp($cacheDir): array
     {
         $helper = new UniqueNodeTypeHelper();
 
         foreach ($this->registry->getManagers() as $documentManager) {
             $helper->checkNodeTypeMappings($documentManager);
         }
+
+        return [];
     }
 }

--- a/src/CacheWarmer/UniqueNodeTypeCacheWarmer.php
+++ b/src/CacheWarmer/UniqueNodeTypeCacheWarmer.php
@@ -29,7 +29,7 @@ final class UniqueNodeTypeCacheWarmer implements CacheWarmerInterface
         return true;
     }
 
-    public function warmUp($cacheDir): array
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         $helper = new UniqueNodeTypeHelper();
 

--- a/src/Command/LoadFixtureCommand.php
+++ b/src/Command/LoadFixtureCommand.php
@@ -4,17 +4,17 @@ namespace Doctrine\Bundle\PHPCRBundle\Command;
 
 use Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
+use Doctrine\ODM\PHPCR\Tools\Console\Helper\DocumentManagerHelper;
 use InvalidArgumentException;
+use PHPCR\Util\Console\Command\BaseCommand;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\DialogHelper;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Command to load PHPCR-ODM fixtures.
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class LoadFixtureCommand extends Command
+class LoadFixtureCommand extends BaseCommand
 {
     use ContainerAwareTrait;
 
@@ -65,28 +65,24 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $dmName = $input->getOption('dm'); // defaults to null
+        $application = $this->getApplication();
+        if (!$application instanceof Application) {
+            throw new \InvalidArgumentException('Expected to find '.Application::class.' but got '.
+                ($application ? \get_class($application) : null));
+        }
         DoctrineCommandHelper::setApplicationDocumentManager(
-            $this->getApplication(),
+            $application,
             $dmName
         );
 
-        $dm = $this->getHelperSet()->get('phpcr')->getDocumentManager();
+        $dm = $this->getPhpcrHelper()->getDocumentManager();
         $noInitialize = $input->getOption('no-initialize');
 
         if ($input->isInteractive() && !$input->getOption('append')) {
             $question = '<question>Careful, database will be purged. Do you want to continue Y/N ?</question>';
-            $default = false;
-            if ($this->getHelperSet()->has('question')) {
-                /** @var $questionHelper QuestionHelper */
-                $questionHelper = $this->getHelperSet()->get('question');
-                $question = new ConfirmationQuestion($question, $default);
-                $result = $questionHelper->ask($input, $output, $question);
-            } else {
-                /** @var $dialog DialogHelper */
-                $dialog = $this->getHelperSet()->get('dialog');
-                $result = $dialog->askConfirmation($output, $question, $default);
-            }
-
+            $questionHelper = $this->getQuestionHelper();
+            $question = new ConfirmationQuestion($question, false);
+            $result = $questionHelper->ask($input, $output, $question);
             if (!$result) {
                 return 0;
             }
@@ -96,8 +92,7 @@ EOT
         if ($dirOrFile) {
             $paths = \is_array($dirOrFile) ? $dirOrFile : [$dirOrFile];
         } else {
-            /** @var $kernel KernelInterface */
-            $kernel = $this->getApplication()->getKernel();
+            $kernel = $application->getKernel();
             $projectDir = method_exists($kernel, 'getRootDir') ? $kernel->getRootDir() : $kernel->getProjectDir().'/src';
             $paths = [$projectDir.'/DataFixtures/PHPCR'];
             foreach ($kernel->getBundles() as $bundle) {
@@ -136,5 +131,13 @@ EOT
         $executor->execute($fixtures, $input->getOption('append'));
 
         return 0;
+    }
+
+    protected function getPhpcrHelper(): DocumentManagerHelper
+    {
+        $helper = parent::getPhpcrHelper();
+        \assert($helper instanceof DocumentManagerHelper);
+
+        return $helper;
     }
 }

--- a/src/Command/MigratorMigrateCommand.php
+++ b/src/Command/MigratorMigrateCommand.php
@@ -9,16 +9,22 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MigratorMigrateCommand extends BaseCommand
 {
-    use ContainerAwareTrait;
+    private const NAME = 'doctrine:phpcr:migrator:migrate';
+
+    public function __construct(
+        private ContainerInterface $container
+    ) {
+        parent::__construct(self::NAME);
+    }
 
     protected function configure(): void
     {
         $this
-            ->setName('doctrine:phpcr:migrator:migrate')
+            ->setName(self::NAME)
             ->setDescription('Migrates PHPCR data.')
             ->addArgument('migrator_name', InputArgument::OPTIONAL, 'The name of the alias/service to be used to migrate the data.')
             ->addOption('identifier', null, InputOption::VALUE_REQUIRED, 'Path or UUID of the node to migrate', '/')

--- a/src/Command/NodeDumpCommand.php
+++ b/src/Command/NodeDumpCommand.php
@@ -8,7 +8,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -16,34 +15,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  */
-class NodeDumpCommand extends BaseDumpCommand implements ContainerAwareInterface
+class NodeDumpCommand extends BaseDumpCommand
 {
-    private ?ContainerInterface $container = null;
-    private PhpcrConsoleDumperHelper $consoleDumper;
+    private const NAME = 'doctrine:phpcr:node:dump';
 
-    protected function getContainer(): ContainerInterface
-    {
-        if (null === $this->container) {
-            $this->container = $this->getApplication()->getKernel()->getContainer();
-        }
-
-        return $this->container;
-    }
-
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        if (!$container) {
-            unset($this->container);
-
-            return;
-        }
-
-        $this->container = $container;
-    }
-
-    public function setConsoleDumper(PhpcrConsoleDumperHelper $consoleDumper): void
-    {
-        $this->consoleDumper = $consoleDumper;
+    public function __construct(
+        private PhpcrConsoleDumperHelper $consoleDumper,
+        private int $dumpMaxLineLength
+    ) {
+        parent::__construct(self::NAME);
     }
 
     protected function configure(): void
@@ -51,7 +31,7 @@ class NodeDumpCommand extends BaseDumpCommand implements ContainerAwareInterface
         parent::configure();
 
         $this
-            ->setName('doctrine:phpcr:node:dump')
+            ->setName(self::NAME)
             ->addOption('session', null, InputOption::VALUE_REQUIRED, 'The session to use for this command')
         ;
     }
@@ -66,10 +46,8 @@ class NodeDumpCommand extends BaseDumpCommand implements ContainerAwareInterface
         $helperSet = $application->getHelperSet();
         $helperSet->set($this->consoleDumper);
 
-        if (!$input->hasOption('max_line_length')
-            && $this->getContainer()->hasParameter('doctrine_phpcr.dump_max_line_length')
-        ) {
-            $input->setOption('max_line_length', $this->getContainer()->getParameter('doctrine_phpcr.dump_max_line_length'));
+        if (!$input->hasOption('max_line_length')) {
+            $input->setOption('max_line_length', $this->dumpMaxLineLength);
         }
 
         return parent::execute($input, $output);

--- a/src/Command/NodeDumpCommand.php
+++ b/src/Command/NodeDumpCommand.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\PHPCRBundle\Command;
 
 use PHPCR\Util\Console\Command\NodeDumpCommand as BaseDumpCommand;
 use PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class NodeDumpCommand extends BaseDumpCommand implements ContainerAwareInterface
 {
-    private ContainerInterface $container;
+    private ?ContainerInterface $container = null;
     private PhpcrConsoleDumperHelper $consoleDumper;
 
     protected function getContainer(): ContainerInterface
@@ -72,5 +73,16 @@ class NodeDumpCommand extends BaseDumpCommand implements ContainerAwareInterface
         }
 
         return parent::execute($input, $output);
+    }
+
+    public function getApplication(): Application
+    {
+        $application = parent::getApplication();
+        if (!$application instanceof Application) {
+            throw new \InvalidArgumentException('Expected to find '.Application::class.' but got '.
+                ($application ? \get_class($application) : null));
+        }
+
+        return $application;
     }
 }

--- a/src/Command/NodeTypeRegisterCommand.php
+++ b/src/Command/NodeTypeRegisterCommand.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\PHPCRBundle\Command;
 
 use PHPCR\Util\Console\Command\NodeTypeRegisterCommand as BaseRegisterNodeTypesCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -34,14 +35,19 @@ EOT;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $application = $this->getApplication();
+        if (!$application instanceof Application) {
+            throw new \InvalidArgumentException('Expected to find '.Application::class.' but got '.
+                ($application ? \get_class($application) : null));
+        }
+
         DoctrineCommandHelper::setApplicationPHPCRSession(
-            $this->getApplication(),
+            $application,
             $input->getOption('session'),
             true
         );
 
         $definitions = $input->getArgument('cnd-file');
-        $application = $this->getApplication();
 
         // if no cnd-files, automatically load from bundles
         if (0 === \count($definitions)) {

--- a/src/DependencyInjection/Compiler/DoctrinePhpcrMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrinePhpcrMappingsPass.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler;
 
-use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\PHPCR\Mapping\Driver\AttributeDriver;
 use Doctrine\ODM\PHPCR\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\PHPCR\Mapping\Driver\YamlDriver;
@@ -120,31 +119,6 @@ final class DoctrinePhpcrMappingsPass extends RegisterMappingsPass
         $driver = new Definition(PHPDriver::class, [$locator]);
 
         return new self($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
-    }
-
-    /**
-     * @param array       $namespaces        List of namespaces that are handled with annotation mapping
-     * @param array       $directories       List of directories to look for annotated classes
-     * @param string[]    $managerParameters List of parameters that could which object manager name
-     *                                       your bundle uses. This compiler pass will automatically
-     *                                       append the parameter name for the default entity manager
-     *                                       to this list.
-     * @param string|bool $enabledParameter  Service container parameter that must be present to
-     *                                       enable the mapping. Set to false to not do any check,
-     *                                       optional.
-     * @param string[]    $aliasMap          map of alias to namespace
-     */
-    public static function createAnnotationMappingDriver(
-        array $namespaces,
-        array $directories,
-        array $managerParameters = [],
-        $enabledParameter = false,
-        array $aliasMap = []
-    ): self {
-        $reader = new Reference('doctrine_phpcr.odm.metadata.annotation_reader');
-        $driver = new Definition(AnnotationDriver::class, [$reader, $directories]);
-
-        return new self($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -331,7 +331,6 @@ final class Configuration implements ConfigurationInterface
                                 ->scalarNode('mapping')->defaultValue(true)->end()
                                 ->scalarNode('type')->end()
                                 ->scalarNode('dir')->end()
-                                ->scalarNode('alias')->end()
                                 ->scalarNode('prefix')->end()
                                 ->booleanNode('is_bundle')->end()
                             ->end()

--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -503,7 +503,6 @@ final class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         // reset state of drivers and alias map. They are only used by this methods and children.
         $this->drivers = [];
         $this->aliasMap = [];
-        $this->bundleDirs = [];
 
         if (!class_exists(Generic::class)) {
             throw new \RuntimeException('PHPCR ODM is activated in the config but does not seem loadable.');

--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -512,7 +512,7 @@ final class DoctrinePHPCRExtension extends AbstractDoctrineExtension
 
         $documentManager['mappings']['__PHPCRODM__'] = [
             'dir' => \dirname($class->getFileName()),
-            'type' => 'annotation',
+            'type' => 'attribute',
             'prefix' => 'Doctrine\ODM\PHPCR\Document',
             'is_bundle' => false,
             'mapping' => true,

--- a/src/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/DependencyInjection/DoctrinePHPCRExtension.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Bundle\PHPCRBundle\DependencyInjection;
 
+use Jackalope\Tools\Console\Command\InitDoctrineDbalCommand as BaseInitDoctrineDbalCommand;
+use Jackalope\Tools\Console\Command\JackrabbitCommand as BaseJackrabbitCommand;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistryInterface;
 use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
@@ -62,8 +64,14 @@ final class DoctrinePHPCRExtension extends AbstractDoctrineExtension
 
         $this->loader->load('phpcr.xml');
         $this->loader->load('commands.xml');
+        if (class_exists(BaseJackrabbitCommand::class)) {
+            $this->loader->load('jackrabbit-commands.xml');
+        }
+        if (class_exists(BaseInitDoctrineDbalCommand::class)) {
+            $this->loader->load('jackalope_doctrine_dbal-commands.xml');
+        }
 
-        // default values in case no odm is configured. the manager registry needs these variables to be defined.
+            // default values in case no odm is configured. the manager registry needs these variables to be defined.
         // if odm is enabled, the parameters are overwritten later in the `loadOdm` section.
         $container->setParameter('doctrine_phpcr.odm.document_managers', []);
         $container->setParameter('doctrine_phpcr.odm.default_document_manager', '');
@@ -500,9 +508,8 @@ final class DoctrinePHPCRExtension extends AbstractDoctrineExtension
 
     private function loadOdmDocumentManagerMappingInformation(array $documentManager, Definition $odmConfig, ContainerBuilder $container): void
     {
-        // reset state of drivers and alias map. They are only used by this methods and children.
+        // reset state of drivers map. It is only used by this methods and children.
         $this->drivers = [];
-        $this->aliasMap = [];
 
         if (!class_exists(Generic::class)) {
             throw new \RuntimeException('PHPCR ODM is activated in the config but does not seem loadable.');
@@ -519,8 +526,6 @@ final class DoctrinePHPCRExtension extends AbstractDoctrineExtension
         ];
         $this->loadMappingInformation($documentManager, $container);
         $this->registerMappingDrivers($documentManager, $container);
-
-        $odmConfig->addMethodCall('setDocumentNamespaces', [$this->aliasMap]);
     }
 
     /**

--- a/src/DoctrinePHPCRBundle.php
+++ b/src/DoctrinePHPCRBundle.php
@@ -5,7 +5,6 @@ namespace Doctrine\Bundle\PHPCRBundle;
 use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\InitializerPass;
 use Doctrine\Bundle\PHPCRBundle\DependencyInjection\Compiler\MigratorPass;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\InitDoctrineDbalCommand;
-use Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\JackrabbitCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\DocumentConvertTranslationCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\DocumentMigrateClassCommand;
 use Doctrine\Bundle\PHPCRBundle\OptionalCommand\ODM\InfoDoctrineCommand;
@@ -14,7 +13,6 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\PHPCR\Version;
 use Jackalope\Session;
 use Jackalope\Tools\Console\Command\InitDoctrineDbalCommand as BaseInitDoctrineDbalCommand;
-use Jackalope\Tools\Console\Command\JackrabbitCommand as BaseJackrabbitCommand;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -50,9 +48,6 @@ class DoctrinePHPCRBundle extends Bundle
             $application->add(new DocumentConvertTranslationCommand());
         }
 
-        if (class_exists(BaseJackrabbitCommand::class)) {
-            $application->add(new JackrabbitCommand());
-        }
         if (class_exists(BaseInitDoctrineDbalCommand::class)) {
             $application->add(new InitDoctrineDbalCommand());
         }
@@ -68,7 +63,7 @@ class DoctrinePHPCRBundle extends Bundle
             $container = &$this->container;
 
             $this->autoloader = function ($class) use ($namespace, $dir, &$container) {
-                if (0 === strpos($class, $namespace)) {
+                if (str_starts_with($class, $namespace)) {
                     $fileName = str_replace('\\', '', substr($class, \strlen($namespace) + 1));
                     $file = $dir.\DIRECTORY_SEPARATOR.$fileName.'.php';
 

--- a/src/DoctrinePHPCRBundle.php
+++ b/src/DoctrinePHPCRBundle.php
@@ -19,7 +19,6 @@ use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListen
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\IntrospectableContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DoctrinePHPCRBundle extends Bundle
@@ -123,10 +122,6 @@ class DoctrinePHPCRBundle extends Bundle
         }
 
         foreach ($this->container->getParameter('doctrine_phpcr.odm.document_managers') as $id) {
-            if ($this->container instanceof IntrospectableContainerInterface && !$this->container->initialized($id)) {
-                continue;
-            }
-
             $this->container->get($id)->clear();
         }
     }
@@ -141,10 +136,6 @@ class DoctrinePHPCRBundle extends Bundle
         }
 
         foreach ($this->container->getParameter('doctrine_phpcr.sessions') as $id) {
-            if ($this->container instanceof IntrospectableContainerInterface && !$this->container->initialized($id)) {
-                continue;
-            }
-
             $session = $this->container->get($id);
             if (!$session instanceof Session) {
                 return;

--- a/src/EventListener/JackalopeDoctrineDbalSchemaListener.php
+++ b/src/EventListener/JackalopeDoctrineDbalSchemaListener.php
@@ -17,6 +17,9 @@ use Jackalope\Transport\DoctrineDBAL\RepositorySchema;
  */
 class JackalopeDoctrineDbalSchemaListener
 {
+    /**
+     * @var RepositorySchema
+     */
     private $schema;
 
     public function __construct(RepositorySchema $schema)

--- a/src/Form/DataTransformer/DocumentToPathTransformer.php
+++ b/src/Form/DataTransformer/DocumentToPathTransformer.php
@@ -20,7 +20,7 @@ class DocumentToPathTransformer implements DataTransformerInterface
      *
      * @param object $document
      */
-    public function transform($document): ?string
+    public function transform(mixed $document): ?string
     {
         if (null === $document) {
             return null;
@@ -36,7 +36,7 @@ class DocumentToPathTransformer implements DataTransformerInterface
      *
      * @return object|null returns the document or null if $path is empty
      */
-    public function reverseTransform($path): ?object
+    public function reverseTransform(mixed $path): ?object
     {
         if (!$path) {
             return null;

--- a/src/Form/PhpcrOdmTypeGuesser.php
+++ b/src/Form/PhpcrOdmTypeGuesser.php
@@ -5,7 +5,7 @@ namespace Doctrine\Bundle\PHPCRBundle\Form;
 use Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType;
 use Doctrine\Bundle\PHPCRBundle\Form\Type\PathType;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistryInterface;
-use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -208,15 +208,16 @@ final class PhpcrOdmTypeGuesser implements FormTypeGuesserInterface
             return new ValueGuess(false, Guess::MEDIUM_CONFIDENCE);
         }
 
-        if ($metadata->hasAssociation($property)) {
-            if ($property === $metadata->parentMapping
-                && ClassMetadata::GENERATOR_TYPE_ASSIGNED !== $metadata->idGenerator
-            ) {
-                return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
-            }
-
-            return new ValueGuess(false, Guess::LOW_CONFIDENCE);
+        if (!$metadata->hasAssociation($property)) {
+            return null;
         }
+        if ($property === $metadata->parentMapping
+            && ClassMetadata::GENERATOR_TYPE_ASSIGNED !== $metadata->idGenerator
+        ) {
+            return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
+        }
+
+        return new ValueGuess(false, Guess::LOW_CONFIDENCE);
     }
 
     public function guessPattern(string $class, string $property): ?ValueGuess
@@ -225,7 +226,7 @@ final class PhpcrOdmTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @return array{0: ClassMetadata, 1: DocumentManager}|null
+     * @return array{0: ClassMetadata, 1: DocumentManagerInterface}|null
      */
     private function getMetadata(string $class): ?array
     {

--- a/src/Initializer/InitializerManager.php
+++ b/src/Initializer/InitializerManager.php
@@ -19,6 +19,11 @@ class InitializerManager
     private ManagerRegistryInterface $registry;
     private ?\Closure $loggingClosure = null;
 
+    /**
+     * @var InitializerInterface[]
+     */
+    private array $sortedInitializers;
+
     public function __construct(ManagerRegistryInterface $registry)
     {
         $this->registry = $registry;
@@ -58,10 +63,10 @@ class InitializerManager
 
             // handle specified session if present
             if ($sessionName) {
-                if (\in_array(SessionAwareInitializerInterface::class, class_implements($initializer))) {
+                if ($initializer instanceof SessionAwareInitializerInterface) {
                     $initializer->setSessionName($sessionName);
                 } elseif ($loggingClosure) {
-                    $loggingClosure(sprintf('<comment>Initializer "%s" does not implement SessionAwareInitializerInterface, "session" parameter will be ommitted.</comment>', $initializer->getName()));
+                    $loggingClosure(sprintf('<comment>Initializer "%s" does not implement SessionAwareInitializerInterface, "session" parameter will be omitted.</comment>', $initializer->getName()));
                 }
             }
 

--- a/src/ManagerRegistry.php
+++ b/src/ManagerRegistry.php
@@ -58,22 +58,34 @@ final class ManagerRegistry extends BaseManagerRegistry implements ManagerRegist
 
     public function getManager($name = null): DocumentManagerInterface
     {
-        return parent::getManager($name);
+        $dm = parent::getManager($name);
+        \assert($dm instanceof DocumentManagerInterface);
+
+        return $dm;
     }
 
     public function resetManager($name = null): DocumentManagerInterface
     {
-        return parent::resetManager($name);
+        $dm = parent::resetManager($name);
+        \assert($dm instanceof DocumentManagerInterface);
+
+        return $dm;
     }
 
     public function getManagerForClass($class = null): ?DocumentManagerInterface
     {
-        return parent::getManagerForClass($class);
+        $dm = parent::getManagerForClass($class);
+        \assert(null === $dm || $dm instanceof DocumentManagerInterface);
+
+        return $dm;
     }
 
     public function getConnection($name = null): SessionInterface
     {
-        return parent::getConnection($name);
+        $conn = parent::getConnection($name);
+        \assert($conn instanceof SessionInterface);
+
+        return $conn;
     }
 
     /**
@@ -92,6 +104,9 @@ final class ManagerRegistry extends BaseManagerRegistry implements ManagerRegist
             throw new \InvalidArgumentException(sprintf('Doctrine %s Connection named "%s" does not exist.', $this->getName(), $name));
         }
 
-        return $this->getService($serviceName);
+        $connection = $this->getService($serviceName);
+        \assert($connection instanceof SessionInterface);
+
+        return $connection;
     }
 }

--- a/src/OptionalCommand/Jackalope/InitDoctrineDbalCommand.php
+++ b/src/OptionalCommand/Jackalope/InitDoctrineDbalCommand.php
@@ -4,6 +4,7 @@ namespace Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope;
 
 use Doctrine\Bundle\PHPCRBundle\Command\DoctrineCommandHelper;
 use Jackalope\Tools\Console\Command\InitDoctrineDbalCommand as BaseInitDoctrineDbalCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,6 +27,11 @@ class InitDoctrineDbalCommand extends BaseInitDoctrineDbalCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $application = $this->getApplication();
+        if (!$application instanceof Application) {
+            throw new \InvalidArgumentException('Expected to find '.Application::class.' but got '.
+                ($application ? \get_class($application) : null));
+        }
+
         $sessionName = $input->getOption('session');
         if (empty($sessionName)) {
             $container = $application->getKernel()->getContainer();

--- a/src/OptionalCommand/Jackalope/JackrabbitCommand.php
+++ b/src/OptionalCommand/Jackalope/JackrabbitCommand.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope;
 
 use Jackalope\Tools\Console\Command\JackrabbitCommand as BaseJackrabbitCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -15,15 +16,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class JackrabbitCommand extends BaseJackrabbitCommand implements ContainerAwareInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    private ?ContainerInterface $container = null;
 
     protected function getContainer(): ContainerInterface
     {
         if (null === $this->container) {
-            $this->container = $this->getApplication()->getKernel()->getContainer();
+            $application = $this->getApplication();
+            if (!$application instanceof Application) {
+                throw new \InvalidArgumentException('Expected to find '.Application::class.' but got '.
+                    ($application ? \get_class($application) : null));
+            }
+
+            $this->container = $application->getKernel()->getContainer();
         }
 
         return $this->container;

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -6,25 +6,20 @@
 
     <services>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\LoadFixtureCommand" class="Doctrine\Bundle\PHPCRBundle\Command\LoadFixtureCommand">
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+            <argument type="service" id="doctrine_phpcr.initializer_manager"/>
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\WorkspaceQueryCommand" class="Doctrine\Bundle\PHPCRBundle\Command\WorkspaceQueryCommand">
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\MigratorMigrateCommand" class="Doctrine\Bundle\PHPCRBundle\Command\MigratorMigrateCommand">
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+            <argument type="service" id="service_container"/>
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\NodeDumpCommand" class="Doctrine\Bundle\PHPCRBundle\Command\NodeDumpCommand">
+            <argument type="service" id="doctrine_phpcr.console_dumper"/>
+            <argument>%doctrine_phpcr.dump_max_line_length%</argument>
             <tag name="console.command"/>
-            <call method="setConsoleDumper">
-                <argument type="service" id="doctrine_phpcr.console_dumper" />
-            </call>
         </service>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\NodeMoveCommand" class="Doctrine\Bundle\PHPCRBundle\Command\NodeMoveCommand">
             <tag name="console.command"/>
@@ -48,9 +43,7 @@
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\RepositoryInitCommand" class="Doctrine\Bundle\PHPCRBundle\Command\RepositoryInitCommand">
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+            <argument type="service" id="doctrine_phpcr.initializer_manager"/>
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\PHPCRBundle\Command\WorkspaceCreateCommand" class="Doctrine\Bundle\PHPCRBundle\Command\WorkspaceCreateCommand">

--- a/src/Resources/config/jackalope_doctrine_dbal-commands.xml
+++ b/src/Resources/config/jackalope_doctrine_dbal-commands.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Doctrine\Bundle\PHPCRBundle\OptionalCommand\InitDoctrineDbalCommand" class="Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\InitDoctrineDbalCommand">
+            <tag name="console.command"/>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/jackrabbit-commands.xml
+++ b/src/Resources/config/jackrabbit-commands.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Doctrine\Bundle\PHPCRBundle\OptionalCommand\JackrabbitCommand" class="Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\JackrabbitCommand">
+            <argument>%doctrine_phpcr.jackrabbit_jar%</argument>
+            <argument>%doctrine_phpcr.workspace_dir%</argument>
+            <tag name="console.command"/>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/odm.xml
+++ b/src/Resources/config/odm.xml
@@ -23,7 +23,6 @@
         <parameter key="doctrine_phpcr.odm.metadata.yml.class">Doctrine\Bundle\PHPCRBundle\Mapping\Driver\YamlDriver</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.php.class">Doctrine\Persistence\Mapping\Driver\StaticPHPDriver</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.driver_chain.class">Doctrine\Persistence\Mapping\Driver\MappingDriverChain</parameter>
-        <parameter key="doctrine_phpcr.odm.metadata.annotation.class">Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver</parameter>
         <parameter key="doctrine_phpcr.odm.metadata.attribute.class">Doctrine\ODM\PHPCR\Mapping\Driver\AttributeDriver</parameter>
     </parameters>
     <services>
@@ -42,7 +41,6 @@
             <argument type="service" id="doctrine_phpcr"/>
         </service>
 
-        <service id="doctrine_phpcr.odm.metadata.annotation_reader" alias="annotation_reader" public="false" />
         <service id="doctrine_phpcr.odm.metadata.attribute_reader" alias="attribute_reader" public="false" />
 
         <service

--- a/tests/Fixtures/App/DataFixtures/PHPCR/LoadData.php
+++ b/tests/Fixtures/App/DataFixtures/PHPCR/LoadData.php
@@ -20,9 +20,6 @@ use Doctrine\Persistence\ObjectManager;
 
 class LoadData implements FixtureInterface
 {
-    /**
-     * @param DocumentManager $manager
-     */
     public function load(ObjectManager $manager): void
     {
         $base = new Generic();

--- a/tests/Fixtures/App/Document/ReferrerDocument.php
+++ b/tests/Fixtures/App/Document/ReferrerDocument.php
@@ -13,36 +13,24 @@ namespace Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+use Doctrine\ODM\PHPCR\Mapping\Attributes as PHPCR;
 
-/**
- * @PHPCR\Document()
- */
+#[PHPCR\Document]
 class ReferrerDocument
 {
-    /**
-     * @PHPCR\Id(strategy="assigned")
-     */
+    #[PHPCR\Id(strategy: 'assigned')]
     public string $id;
 
-    /**
-     * @PHPCR\ReferenceOne()
-     */
+    #[PHPCR\ReferenceOne]
     protected $single;
 
-    /**
-     * @PHPCR\ReferenceMany()
-     */
+    #[PHPCR\ReferenceMany]
     protected Collection $documents;
 
-    /**
-     * @PHPCR\ReferenceOne(targetDocument="Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document\TestDocument")
-     */
+    #[PHPCR\ReferenceOne(targetDocument: TestDocument::class)]
     protected $testDocument;
 
-    /**
-     * @PHPCR\ReferenceMany(targetDocument="Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document\TestDocument")
-     */
+    #[PHPCR\ReferenceMany(targetDocument: TestDocument::class)]
     protected Collection $testDocuments;
 
     public function __construct()

--- a/tests/Fixtures/App/Document/TestDocument.php
+++ b/tests/Fixtures/App/Document/TestDocument.php
@@ -6,9 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\PHPCR\Mapping\Attributes as PHPCR;
 
-/**
- * @PHPCR\Document(referenceable=true)
- */
 #[PHPCR\Document(referenceable: true)]
 class TestDocument
 {

--- a/tests/Fixtures/App/Document/TestDocument.php
+++ b/tests/Fixtures/App/Document/TestDocument.php
@@ -4,115 +4,73 @@ namespace Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+use Doctrine\ODM\PHPCR\Mapping\Attributes as PHPCR;
 
 /**
  * @PHPCR\Document(referenceable=true)
  */
+#[PHPCR\Document(referenceable: true)]
 class TestDocument
 {
-    /**
-     * @PHPCR\Id()
-     */
+    #[PHPCR\Id]
     public string $id;
 
-    /**
-     * @PHPCR\ParentDocument()
-     */
+    #[PHPCR\ParentDocument]
     public $parent;
 
-    /**
-     * @PHPCR\Nodename()
-     */
+    #[PHPCR\Nodename]
     public string $nodename;
 
-    /**
-     * @PHPCR\Uuid
-     */
+    #[PHPCR\Uuid]
     public string $uuid;
 
-    /**
-     * @PHPCR\Child()
-     */
+    #[PHPCR\Child]
     public $child;
 
-    /**
-     * @PHPCR\Children()
-     */
+    #[PHPCR\Children]
     protected Collection $children;
 
-    /**
-     * @PHPCR\Referrers(
-     *     referringDocument="Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document\ReferrerDocument",
-     *     referencedBy="documents"
-     * )
-     */
+    #[PHPCR\Referrers(referencedBy: 'documents', referringDocument: ReferrerDocument::class)]
     protected Collection $referrers;
 
-    /**
-     * @PHPCR\MixedReferrers()
-     */
+    #[PHPCR\MixedReferrers]
     protected Collection $mixedReferrers;
 
-    /**
-     * @PHPCR\Field(type="boolean")
-     */
+    #[PHPCR\Field(type: 'boolean')]
     public bool $bool;
 
-    /**
-     * @PHPCR\Field(type="date")
-     */
+    #[PHPCR\Field(type: 'date')]
     public \DateTimeInterface $date;
 
-    /**
-     * @PHPCR\Field(type="string")
-     */
+    #[PHPCR\Field(type: 'string')]
     public string $text;
 
-    /**
-     * @PHPCR\Field(type="double")
-     */
+    #[PHPCR\Field(type: 'double')]
     public float $number;
 
-    /**
-     * @PHPCR\Field(type="long")
-     */
+    #[PHPCR\Field(type: 'long')]
     public int $long;
 
-    /**
-     * @PHPCR\Field(type="int")
-     */
+    #[PHPCR\Field(type: 'int')]
     public int $integer;
 
-    /**
-     * @PHPCR\Field(type="boolean", multivalue=true, nullable=true)
-     */
-    public array $mbool;
+    #[PHPCR\Field(type: 'boolean', multivalue: true, nullable: true)]
+    public ?array $mbool;
 
-    /**
-     * @PHPCR\Field(type="date", multivalue=true, nullable=true)
-     */
-    public array $mdate;
+    #[PHPCR\Field(type: 'date', multivalue: true, nullable: true)]
+    public ?array $mdate;
 
-    /**
-     * @PHPCR\Field(type="string", multivalue=true, nullable=true)
-     */
-    public array $mtext;
+    #[PHPCR\Field(type: 'string', multivalue: true, nullable: true)]
+    public ?array $mtext;
 
-    /**
-     * @PHPCR\Field(type="double", multivalue=true, nullable=true)
-     */
-    public array $mnumber;
+    #[PHPCR\Field(type: 'double', multivalue: true, nullable: true)]
+    public ?array $mnumber;
 
-    /**
-     * @PHPCR\Field(type="long", multivalue=true, nullable=true)
-     */
-    public array $mlong;
+    #[PHPCR\Field(type: 'long', multivalue: true, nullable: true)]
+    public ?array $mlong;
 
-    /**
-     * @PHPCR\Field(type="int", multivalue=true, nullable=true)
-     */
-    public array $minteger;
+    #[PHPCR\Field(type: 'int', multivalue: true, nullable: true)]
+    public ?array $minteger;
 
     public function __construct()
     {

--- a/tests/Fixtures/App/Kernel.php
+++ b/tests/Fixtures/App/Kernel.php
@@ -32,7 +32,7 @@ class Kernel extends HttpKernel
         }
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config/config.php');
     }

--- a/tests/Fixtures/App/config/doctrine.yaml
+++ b/tests/Fixtures/App/config/doctrine.yaml
@@ -23,7 +23,7 @@ doctrine_phpcr:
             fr: [en, de]
         mappings:
             test_additional:
-                type: annotation
+                type: attribute
                 prefix: Doctrine\Bundle\PHPCRBundle\Tests\Fixtures\App\Document
                 dir: "%kernel.project_dir%/Document"
                 is_bundle: false

--- a/tests/Fixtures/App/config/framework.yaml
+++ b/tests/Fixtures/App/config/framework.yaml
@@ -1,6 +1,5 @@
 framework:
     secret: test
-    annotations: ~
     property_access: ~
     test: ~
     form: ~

--- a/tests/Fixtures/fixtures/config/single.php
+++ b/tests/Fixtures/fixtures/config/single.php
@@ -38,7 +38,6 @@ $container->loadFromExtension('doctrine_phpcr', [
                 'mapping' => true,
                 'type' => null,
                 'dir' => null,
-                'alias' => null,
                 'prefix' => null,
                 'is-bundle' => null,
             ],

--- a/tests/Fixtures/fixtures/config/single.xml
+++ b/tests/Fixtures/fixtures/config/single.xml
@@ -43,7 +43,6 @@
                     mapping="true"
                     type="null"
                     dir="null"
-                    alias="null"
                     prefix="null"
                     is-bundle="null"
                 />

--- a/tests/Fixtures/fixtures/config/single.yml
+++ b/tests/Fixtures/fixtures/config/single.yml
@@ -26,7 +26,6 @@ doctrine_phpcr:
                 mapping:              true
                 type:                 ~
                 dir:                  ~
-                alias:                ~
                 prefix:               ~
                 is_bundle:            ~
         auto_generate_proxy_classes: true

--- a/tests/Functional/BaseTestCase.php
+++ b/tests/Functional/BaseTestCase.php
@@ -17,8 +17,9 @@ abstract class BaseTestCase extends WebTestCase
         if (!self::$kernel->getContainer()) {
             self::$kernel->boot();
         }
+        $container = self::getTestContainer();
 
-        return new RepositoryManager(self::getTestContainer());
+        return new RepositoryManager($container->get('doctrine_phpcr'), $container->get('doctrine_phpcr.initializer_manager'));
     }
 
     protected function assertResponseSuccess(Response $response): void

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -93,7 +93,6 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                                 'mapping' => true,
                                 'type' => null,
                                 'dir' => null,
-                                'alias' => null,
                                 'prefix' => null,
                                 'is_bundle' => true,
                             ],


### PR DESCRIPTION
* [x] phpcr-odm needs to support attributes in addition to annotations
* [x] Switch setup to use attributes when using symfony 7
* [x] ~or should we register our own doctrine annotations service to be able to continue support annotations for now?~