### PR TITLE
declare conflict with doctrine/persistence 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     },
     "conflict": {
         "doctrine/doctrine-bundle": "< 2.0.3",
+        "doctrine/persistence": "< 3.0.0",
         "doctrine/phpcr-odm": "< 2.0",
         "jackalope/jackalope-jackrabbit": "<2",
         "jackalope/jackalope": "< 1.3.1",


### PR DESCRIPTION
fix #402

when we dropped code for legacy versions, we did not realize that this bundle allowed installation with doctrine/persistence 2.x which has the getAliasNamespace method on the ManagerRegistry interface.