### PR TITLE
Add supported range of jackalope packages to composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 2
 2.5.1
 -----
 
+ * Add supported range of jackalope packages to composer.json
 * Fix dependencies: phpcr-odm 2.0 has BC breaks not supported by this legacy version of the bundle.
   To use phpcr-odm `2.*`, please use version 3 of this bundle.
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
     "conflict": {
         "doctrine/annotations": "< 1.7.0",
         "doctrine/phpcr-odm": "< 1.5.2 || >= 2.0",
-        "jackalope/jackalope": "< 1.3.1",
+        "jackalope/jackalope": "< 1.3.1 || >= 2.0.0",
+        "jackalope/jackalope-doctrine-dbal": "< 1.3.0 || >= 2.0.0",
+        "jackalope/jackalope-jackrabbit": "< 1.3.0 || >= 2.0.0",
         "phpcr/phpcr-shell": "< 1.0.0-beta1",
         "symfony/dependency-injection": "4.0.0",
         "twig/twig": "< 1.42.3"


### PR DESCRIPTION
Problem the latest version of `2.x` PHPCR Bundle also installs the jackalope 2.0 packages:

```
  - Locking doctrine/phpcr-bundle (2.5.0)
  - Locking jackalope/jackalope (2.0.0)
  - Locking jackalope/jackalope-doctrine-dbal (2.0.1)
```

https://github.com/sulu/SuluHeadlessBundle/actions/runs/9760192331/job/26938459924?pr=139

But this ends on PHP 8.0 and 8.1 with: 

> PHP Fatal error:  Declaration of Doctrine\Bundle\PHPCRBundle\OptionalCommand\Jackalope\InitDoctrineDbalCommand::configure() must be compatible with Jackalope\Tools\Console\Command\InitDoctrineDbalCommand::configure(): void in /home/runner/work/SuluHeadlessBundle/SuluHeadlessBundle/vendor/doctrine/phpcr-bundle/src/OptionalCommand/Jackalope/InitDoctrineDbalCommand.php on line 19

As the return types are correctly only added on the PHPCR 3.0 branch to avoid bc breaks. See https://github.com/doctrine/DoctrinePHPCRBundle/pull/382.

Still the Sulu Bundles will require to atleast set the new version as min requirement else it could happen that 2.5.0 instead of 2.5.1 (including this PR changes) will be installed.